### PR TITLE
fix: only login with user with domain coderpush.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=get-from-google-oauth-client-id
 TEST_USER_PASSWORD=Test123!
 JWT_SECRET=your-secure-secret
+COMPANY_EMAIL_DOMAIN=@yourcompany.com

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -17,7 +17,8 @@ export async function GET(request: NextRequest) {
       const email = user?.email
 
       // Check if the email is from your company domain
-      if (!email || !email.endsWith('@coderpush.com')) {
+      const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+      if (!email || !email.endsWith(companyDomain)) {
         // Sign out the user
         await supabase.auth.signOut()
         // Redirect to an error page or login with a message

--- a/src/app/auth/invalid-domain/page.tsx
+++ b/src/app/auth/invalid-domain/page.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ShieldAlert } from "lucide-react";
 
+const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+
 export default function InvalidDomainPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-blue-50 via-violet-100 to-teal-100 p-0">
@@ -18,7 +20,7 @@ export default function InvalidDomainPage() {
               <ShieldAlert className="w-5 h-5 text-violet-500" /> Access Denied
             </AlertTitle>
             <div className="mt-2 text-blue-800 text-center">
-              You must sign in with your <span className="font-semibold text-indigo-600">@coderpush.com</span> email address.<br />
+              You must sign in with your <span className="font-semibold text-indigo-600">{companyDomain}</span> email address.<br />
             </div>
           </Alert>
           <Button asChild className="w-full bg-blue-600 hover:bg-blue-700 text-white text-lg font-semibold py-3 rounded-lg shadow-md transition">


### PR DESCRIPTION
## Summary by Sourcery

Restrict login to users with coderpush.com email addresses and introduce an error page for invalid domain attempts.

New Features:
- Add an error page for users attempting to log in with a non-coderpush.com email.

Enhancements:
- Restrict authentication to only allow users with coderpush.com email addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users must now sign in with an email from a specified company domain, configurable via an environment variable.
  - An informative error page guides users who attempt to sign in with an invalid email domain, including a clear message and a "Back to Login" button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->