### PR TITLE
feat: use vercel cron jobs to send email auto

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID=get-from-google-oauth-client-id
 TEST_USER_PASSWORD=Test123!
 JWT_SECRET=your-secure-secret
 COMPANY_EMAIL_DOMAIN=@yourcompany.com
+CRON_SECRET=your-secure-random-string

--- a/docs/auto-reminder-cron.md
+++ b/docs/auto-reminder-cron.md
@@ -5,8 +5,9 @@ This document describes how to implement an automatic reminder system for weekly
 ## Overview
 - Automatically send reminders to users who have not submitted their weekly pulse.
 - Reminders are sent at:
-  - **Friday 5 PM** (form opens)
-  - **Monday 2 PM** (remind users who have not submitted)
+  - **Friday 5 PM UTC+7** (form opens)
+  - **Monday 2 PM UTC+7** (remind users who have not submitted)
+  - **Tuesday 5 PM UTC+7** (late reminder)
 - Uses Vercel Cron Jobs to trigger reminders.
 - Leverages existing reminder logic and templates.
 
@@ -27,11 +28,15 @@ Add the following to your `vercel.json`:
   "crons": [
     {
       "path": "/api/cron/reminders",
-      "schedule": "0 17 * * 5"  // Friday at 5 PM
+      "schedule": "0 10 * * 5"  // Friday at 5 PM UTC+7 (10:00 UTC)
     },
     {
       "path": "/api/cron/reminders",
-      "schedule": "0 14 * * 1"  // Monday at 2 PM
+      "schedule": "0 7 * * 1"   // Monday at 2 PM UTC+7 (07:00 UTC)
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 10 * * 2"  // Tuesday at 5 PM UTC+7 (10:00 UTC)
     }
   ]
 }

--- a/docs/auto-reminder-cron.md
+++ b/docs/auto-reminder-cron.md
@@ -1,0 +1,74 @@
+# Automatic Reminder System with Vercel Cron Jobs
+
+This document describes how to implement an automatic reminder system for weekly pulse submissions using Vercel Cron Jobs and Supabase.
+
+## Overview
+- Automatically send reminders to users who have not submitted their weekly pulse.
+- Reminders are sent at:
+  - **Friday 5 PM** (form opens)
+  - **Monday 2 PM** (remind users who have not submitted)
+- Uses Vercel Cron Jobs to trigger reminders.
+- Leverages existing reminder logic and templates.
+
+## Steps
+
+### 1. Create a New API Route for Cron Jobs
+- Path: `src/app/api/cron/reminders/route.ts`
+- This route:
+  - Runs automatically at scheduled times
+  - Finds users who haven't submitted for the current week
+  - Sends reminders using the existing reminder logic
+
+### 2. Vercel Cron Configuration
+Add the following to your `vercel.json`:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 17 * * 5"  // Friday at 5 PM
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 14 * * 1"  // Monday at 2 PM
+    }
+  ]
+}
+```
+
+### 3. Implementation Details
+
+#### a. Create the Cron Route
+- Implement logic to:
+  - Authenticate using a secret token
+  - Find users who have not submitted for the current week
+  - Call the existing reminder API with the list of users
+
+#### b. Environment Variables
+Add to your `.env`:
+```
+CRON_SECRET=your-secure-random-string
+```
+
+#### c. Security
+- The cron route is protected by a secret token
+- Only Vercel can trigger the cron jobs
+
+#### d. Testing
+- Test the cron route locally using `curl` or similar tools
+- Verify emails are sent and logs are created
+
+#### e. Deployment
+1. Add the `vercel.json` configuration
+2. Set up the `CRON_SECRET` in Vercel environment variables
+3. Deploy to Vercel
+4. Monitor the first few runs
+
+### 4. Notes on Existing Reminder Logic
+- The reminder logic in `src/app/api/admin/submissions/remind/route.ts` is reused
+- Handles different templates based on reminder count
+- 24-hour cooldown between reminders
+- Proper logging and error handling
+
+---

--- a/docs/auto-reminder-cron.md
+++ b/docs/auto-reminder-cron.md
@@ -1,6 +1,6 @@
 # Automatic Reminder System with Vercel Cron Jobs
 
-This document describes how to implement an automatic reminder system for weekly pulse submissions using Vercel Cron Jobs and Supabase.
+This document describes how to implement an automatic reminder system for weekly pulse submissions using Vercel Cron Jobs
 
 ## Overview
 - Automatically send reminders to users who have not submitted their weekly pulse.
@@ -22,7 +22,7 @@ This document describes how to implement an automatic reminder system for weekly
 ### 2. Vercel Cron Configuration
 Add the following to your `vercel.json`:
 
-```json
+```json5
 {
   "crons": [
     {
@@ -52,8 +52,8 @@ CRON_SECRET=your-secure-random-string
 ```
 
 #### c. Security
-- The cron route is protected by a secret token
-- Only Vercel can trigger the cron jobs
+- Cron jobs are triggered by Vercel per schedule.
+	- The endpoint is secured with `CRON_SECRET` to prevent unauthorized execution.
 
 #### d. Testing
 - Test the cron route locally using `curl` or similar tools

--- a/src/app/api/admin/submissions/remind/route.test.ts
+++ b/src/app/api/admin/submissions/remind/route.test.ts
@@ -225,6 +225,59 @@ describe('/api/admin/submissions/remind POST Handler', () => {
     });
   });
 
+  // --- CRON_SECRET Header Authentication ---
+  describe('CRON_SECRET Header Authentication', () => {
+    const CRON_SECRET = 'test-cron-secret';
+    beforeAll(() => {
+      process.env.CRON_SECRET = CRON_SECRET;
+    });
+    afterAll(() => {
+      delete process.env.CRON_SECRET;
+    });
+
+    it('should allow request with valid CRON_SECRET header and bypass user/admin checks', async () => {
+      const user = createMockUser('cron1');
+      const week = 30;
+      const year = 2024;
+      const requestBody = { userIds: [user.id], week, year };
+      const mockRequest = createMockRequest(requestBody, { authorization: `Bearer ${CRON_SECRET}` });
+
+      // Should NOT call user/admin checks, so no need to mockGetUser or mockSingle
+      // Only mock user fetch and downstream DB/email
+      mocks.mockIn.mockResolvedValueOnce({ data: [user], error: null });
+      mocks.mockGte.mockResolvedValueOnce({ data: [], error: null });
+      mocks.mockOrder.mockResolvedValueOnce({ count: 0, error: null });
+      mocks.mockInsert.mockResolvedValueOnce({ error: null });
+      mockSendEmail.mockResolvedValueOnce({ success: true });
+
+      const response = await POST(mockRequest);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        results: [{ userId: user.id, success: true }]
+      });
+      // Optionally, check that no user/admin check mocks were called
+      expect(mocks.mockGetUser).not.toHaveBeenCalled();
+      expect(mocks.mockSingle).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for invalid CRON_SECRET header', async () => {
+      const user = createMockUser('cron2');
+      const week = 31;
+      const year = 2024;
+      const requestBody = { userIds: [user.id], week, year };
+      const mockRequest = createMockRequest(requestBody, { authorization: 'Bearer wrong-secret' });
+
+      // Should fall back to user check, so mockGetUser returns null (unauthenticated)
+      mocks.mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+      const response = await POST(mockRequest);
+      expect(response.status).toBe(401);
+      expect(await response.text()).toBe('Unauthorized');
+    });
+  });
+
   describe('Template Selection', () => {
     it('should use onTimeTemplate and type "on-time" for the first reminder (count=0)', async () => {
       const user = createMockUser('1');

--- a/src/app/api/admin/submissions/remind/route.test.ts
+++ b/src/app/api/admin/submissions/remind/route.test.ts
@@ -43,8 +43,13 @@ const createMockUser = (id: string): MockUser => ({
   name: `User ${id}`,
 });
 
-const createMockRequest = (body: ReminderRequest): Request => {
-  return { json: async () => body } as Request;
+const createMockRequest = (body: ReminderRequest, headers: Record<string, string> = {}): Request => {
+  return {
+    json: async () => body,
+    headers: {
+      get: (key: string) => headers[key],
+    },
+  } as unknown as Request;
 };
 
 // --- Test Suite ---

--- a/src/app/api/cron/reminders/route.test.ts
+++ b/src/app/api/cron/reminders/route.test.ts
@@ -66,12 +66,26 @@ describe('/api/cron/reminders GET Handler', () => {
     mocks.mockEq.mockResolvedValueOnce({ data: [{ user_id: '1' }], error: null });
     global.fetch = vi.fn().mockResolvedValue({
       headers: { get: () => 'application/json' },
-      json: async () => ({ results: [{ userId: '2', success: true }] })
+      json: async () => ({ results: [{ userId: '2', success: true }] }),
+      status: 200
     });
     const req = createMockRequest({ authorization: 'Bearer test-secret' });
     const res = await GET(req);
     const json = await res.json();
-    expect(json).toEqual({ results: [{ userId: '2', success: true }] });
+    expect(json).toEqual({
+      results: [
+        {
+          userId: '1',
+          response: { results: [{ userId: '2', success: true }] },
+          status: 200
+        },
+        {
+          userId: '2',
+          response: { results: [{ userId: '2', success: true }] },
+          status: 200
+        }
+      ]
+    });
     expect(global.fetch).toHaveBeenCalledWith(
       'http://localhost:3000/api/admin/submissions/remind',
       expect.objectContaining({ method: 'POST' })
@@ -100,7 +114,20 @@ describe('/api/cron/reminders GET Handler', () => {
     const req = createMockRequest({ authorization: 'Bearer test-secret' });
     const res = await GET(req);
     const json = await res.json();
-    expect(json).toEqual({ error: 'Downstream error', status: 500 });
+    expect(json).toEqual({
+      results: [
+        {
+          userId: '1',
+          response: { error: 'Downstream error', status: 500 },
+          status: 500
+        },
+        {
+          userId: '2',
+          response: { error: 'Downstream error', status: 500 },
+          status: 500
+        }
+      ]
+    });
     expect(res.status).toBe(500);
   });
 }); 

--- a/src/app/api/cron/reminders/route.test.ts
+++ b/src/app/api/cron/reminders/route.test.ts
@@ -34,7 +34,7 @@ describe('/api/cron/reminders GET Handler', () => {
   const mockCreateClient = createClient as Mock;
   const mockGetMostRecentThursdayWeek = getMostRecentThursdayWeek as Mock;
   const OLD_ENV = process.env;
-  let GET: any;
+  let GET: (req: Request) => Promise<Response>;
 
   beforeAll(async () => {
     process.env.CRON_SECRET = 'test-secret';

--- a/src/app/api/cron/reminders/route.test.ts
+++ b/src/app/api/cron/reminders/route.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { createClient } from '@/utils/supabase/server';
+import { getMostRecentThursdayWeek } from '@/lib/utils/date';
+import { setupSupabaseMocks } from '@/test-utils/supabase-mocks';
+
+vi.mock('@/utils/supabase/server');
+vi.mock('@/lib/utils/date', () => ({
+  getMostRecentThursdayWeek: vi.fn()
+}));
+
+// --- Helper Types ---
+type MockUser = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+const createMockUser = (id: string): MockUser => ({
+  id,
+  email: `user${id}@example.com`,
+  name: `User ${id}`,
+});
+
+const createMockRequest = (headers: Record<string, string> = {}): Request => {
+  return {
+    headers: {
+      get: (key: string) => headers[key],
+    },
+  } as unknown as Request;
+};
+
+describe('/api/cron/reminders GET Handler', () => {
+  const mocks = setupSupabaseMocks();
+  const mockCreateClient = createClient as Mock;
+  const mockGetMostRecentThursdayWeek = getMostRecentThursdayWeek as Mock;
+  const OLD_ENV = process.env;
+  let GET: any;
+
+  beforeAll(async () => {
+    process.env.CRON_SECRET = 'test-secret';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+    GET = (await import('./route')).GET;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateClient.mockReturnValue(mocks.mockSupabaseClient);
+    mockGetMostRecentThursdayWeek.mockReturnValue(25);
+    process.env = { ...OLD_ENV, CRON_SECRET: 'test-secret', NEXT_PUBLIC_APP_URL: 'http://localhost:3000' };
+  });
+
+
+  it('should return 401 if authorization header is missing or invalid', async () => {
+    const reqNoAuth = createMockRequest();
+    const reqWrongAuth = createMockRequest({ authorization: 'Bearer wrong' });
+    let res = await GET(reqNoAuth);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe('Unauthorized');
+    res = await GET(reqWrongAuth);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe('Unauthorized');
+  });
+
+  it('should call downstream API and return its result if users need reminders', async () => {
+    mocks.mockSelect.mockResolvedValueOnce({ data: [createMockUser('1'), createMockUser('2')], error: null });
+    mocks.mockEq.mockResolvedValueOnce({ data: [{ user_id: '1' }], error: null });
+    global.fetch = vi.fn().mockResolvedValue({
+      headers: { get: () => 'application/json' },
+      json: async () => ({ results: [{ userId: '2', success: true }] })
+    });
+    const req = createMockRequest({ authorization: 'Bearer test-secret' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json).toEqual({ results: [{ userId: '2', success: true }] });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/admin/submissions/remind',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('should return 500 if supabase user fetch fails', async () => {
+    mocks.mockSelect.mockResolvedValueOnce({ eq: vi.fn(() => mocks.mockEq) });
+    mocks.mockEq.mockReturnValueOnce({ eq: mocks.mockEq });
+    mocks.mockEq.mockResolvedValueOnce({ data: null, error: { message: 'fail' } });
+    const req = createMockRequest({ authorization: 'Bearer test-secret' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(res.status).toBe(500);
+    expect(json).toEqual({ error: 'Failed to fetch users' });
+  });
+
+  it('should return downstream error if downstream API returns non-JSON', async () => {
+    mocks.mockSelect.mockResolvedValueOnce({ data: [createMockUser('1'), createMockUser('2')], error: null });
+    mocks.mockEq.mockResolvedValueOnce({ data: [{ user_id: '1' }], error: null });
+    global.fetch = vi.fn().mockResolvedValue({
+      headers: { get: () => 'text/plain' },
+      text: async () => 'Downstream error',
+      status: 500
+    });
+    const req = createMockRequest({ authorization: 'Bearer test-secret' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json).toEqual({ error: 'Downstream error', status: 500 });
+    expect(res.status).toBe(500);
+  });
+}); 

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: Request) {
   // Authenticate using CRON_SECRET
   const authHeader = request.headers.get('authorization');
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse('Unauthorized', { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const supabase = await createClient();

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,0 +1,66 @@
+import { createClient } from '@/utils/supabase/server';
+import { NextResponse } from 'next/server';
+import { getMostRecentThursdayWeek } from '@/lib/utils/date';
+
+export async function GET(request: Request) {
+  // Authenticate using CRON_SECRET
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const supabase = await createClient();
+  const week = getMostRecentThursdayWeek();
+  const year = new Date().getFullYear();
+
+  // Find users who have NOT submitted for this week
+  // 1. Get all user IDs
+  const { data: allUsers, error: usersError } = await supabase
+    .from('users')
+    .select('id, email, name');
+  if (usersError || !allUsers) {
+    return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 });
+  }
+
+  // 2. Get all user IDs who HAVE submitted for this week
+  const { data: submitted, error: submittedError } = await supabase
+    .from('submissions')
+    .select('user_id')
+    .eq('week_number', week)
+    .eq('year', year);
+  if (submittedError) {
+    return NextResponse.json({ error: 'Failed to fetch submissions' }, { status: 500 });
+  }
+  const submittedIds = new Set((submitted || []).map(s => s.user_id));
+
+  // 3. Filter users who have NOT submitted
+  const usersToRemind = allUsers.filter(u => !submittedIds.has(u.id));
+  if (!usersToRemind.length) {
+    return NextResponse.json({ message: 'No users need reminders' });
+  }
+
+  // 4. Call the existing reminder API
+  const remindRes = await fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/admin/submissions/remind`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.CRON_SECRET}`
+    },
+    body: JSON.stringify({
+      userIds: usersToRemind.map(u => u.id),
+      week,
+      year
+    })
+  });
+
+  // Handle non-JSON error responses
+  let remindJson;
+  const contentType = remindRes.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    remindJson = await remindRes.json();
+  } else {
+    const text = await remindRes.text();
+    return NextResponse.json({ error: text, status: remindRes.status }, { status: remindRes.status });
+  }
+  return NextResponse.json(remindJson);
+} 

--- a/src/test-utils/supabase-mocks.ts
+++ b/src/test-utils/supabase-mocks.ts
@@ -12,6 +12,17 @@ export const setupSupabaseMocks = () => {
   const mockFrom = vi.fn();
   const mockGetUser = vi.fn();
 
+  // Helper to allow .eq().eq().single().order() chaining
+  const makeEqChain = () => {
+    const chain: any = {};
+    chain.eq = vi.fn(() => chain);
+    chain.single = mockSingle;
+    chain.order = mockOrder;
+    chain.in = mockIn;
+    chain.gte = mockGte;
+    return chain;
+  };
+
   const mockSupabaseClient = {
     auth: { getUser: mockGetUser },
     from: mockFrom,
@@ -21,27 +32,22 @@ export const setupSupabaseMocks = () => {
   mockFrom.mockImplementation(() => ({
     select: (selectArg: string, options?: { count: 'exact' }) => {
       if (options?.count === 'exact') {
-         // This setup was working - mockSelectWithOptions returns eq
-        mockSelectWithOptions.mockReturnValue({ eq: mockEq });
+        mockSelectWithOptions.mockReturnValue(makeEqChain());
         return mockSelectWithOptions(selectArg, options);
       }
-       // This setup was working - mockSelect returns eq and in
-      mockSelect.mockReturnValue({ eq: mockEq, in: mockIn });
+      mockSelect.mockReturnValue(makeEqChain());
       return mockSelect(selectArg);
     },
     insert: mockInsert,
   }));
 
-  // Default resolutions/chaining setup - Mimic original
-  // This setup seemed sufficient for the tests passed
-  mockEq.mockReturnValue({ eq: mockEq, single: mockSingle, order: mockOrder }); // Allows eq chaining, single, order
-  mockIn.mockReturnValue({ gte: mockGte }); // in returns gte
-  mockGte.mockResolvedValue({ data: [], error: null }); // gte resolves
-  mockSingle.mockResolvedValue({ data: null, error: null }); // single resolves
-  mockOrder.mockResolvedValue({ data: null, error: null, count: 0 }); // order resolves
-  mockInsert.mockResolvedValue({ data: null, error: null }); // insert resolves
+  // Default resolutions/chaining setup
+  mockIn.mockReturnValue(makeEqChain());
+  mockGte.mockResolvedValue({ data: [], error: null });
+  mockSingle.mockResolvedValue({ data: null, error: null });
+  mockOrder.mockResolvedValue({ data: null, error: null, count: 0 });
+  mockInsert.mockResolvedValue({ data: null, error: null });
 
-  // Return all mocks needed by the tests
   return {
     mockEq,
     mockIn,

--- a/src/test-utils/supabase-mocks.ts
+++ b/src/test-utils/supabase-mocks.ts
@@ -14,12 +14,13 @@ export const setupSupabaseMocks = () => {
 
   // Helper to allow .eq().eq().single().order() chaining
   const makeEqChain = () => {
-    const chain: any = {};
-    chain.eq = vi.fn(() => chain);
-    chain.single = mockSingle;
-    chain.order = mockOrder;
-    chain.in = mockIn;
-    chain.gte = mockGte;
+    const chain = {
+      eq: vi.fn(() => chain),
+      single: mockSingle,
+      order: mockOrder,
+      in: mockIn,
+      gte: mockGte,
+    };
     return chain;
   };
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 17 * * 5"
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 14 * * 1"
+    }
+  ]
+} 

--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,15 @@
   "crons": [
     {
       "path": "/api/cron/reminders",
-      "schedule": "0 17 * * 5"
+      "schedule": "0 10 * * 5"
     },
     {
       "path": "/api/cron/reminders",
-      "schedule": "0 14 * * 1"
+      "schedule": "0 7 * * 1"
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 10 * * 2"
     }
   ]
 } 


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic weekly reminder emails via Vercel Cron Jobs by adding a dedicated cron route and secret-based authentication while reusing existing reminder logic.

New Features:
- Add new GET /api/cron/reminders endpoint to identify non-submitters and invoke the admin reminder API
- Configure Vercel Cron Jobs in vercel.json to schedule reminders on Fridays at 5 PM and Mondays at 2 PM
- Provide user-facing documentation for setting up and testing the automatic reminder system

Enhancements:
- Allow the existing admin reminder route to bypass standard auth when invoked with a CRON_SECRET

Chores:
- Update .env.example to include CRON_SECRET for secure cron authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated weekly reminder system for pulse submissions, sending reminders on Fridays at 5 PM, Mondays at 2 PM, and Tuesdays at 5 PM.
  - Added a new API endpoint to trigger reminders for users who have not submitted their weekly data.
- **Documentation**
  - Added detailed documentation outlining the automated reminder system, setup instructions, and security considerations.
- **Chores**
  - Updated environment example file to include a new secret key for cron job authentication.
  - Added configuration for scheduled cron jobs to automate reminder delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->