### PR TITLE
fix: only auto fill the previous manager if the field is truly unset

### DIFF
--- a/src/components/screens/ManagerScreen.tsx
+++ b/src/components/screens/ManagerScreen.tsx
@@ -8,6 +8,7 @@ export default function ManagerScreen({ onNext, onBack, formData, setFormData, u
   const [dontKnow, setDontKnow] = useState(false);
   const [fetchedPreviousManager, setFetchedPreviousManager] = useState<string | null>(null);
   const [isLoadingPreviousManager, setIsLoadingPreviousManager] = useState(true);
+  const [hasInteracted, setHasInteracted] = useState(false);
 
   useEffect(() => {
     if (userId && currentWeekNumber && currentYear) {
@@ -31,7 +32,7 @@ export default function ManagerScreen({ onNext, onBack, formData, setFormData, u
   useEffect(() => {
     if (
       !isLoadingPreviousManager &&
-      (formData.manager === undefined || formData.manager === null) &&
+      !hasInteracted &&
       fetchedPreviousManager
     ) {
       setFormData({
@@ -39,7 +40,7 @@ export default function ManagerScreen({ onNext, onBack, formData, setFormData, u
         manager: fetchedPreviousManager
       });
     }
-  }, [isLoadingPreviousManager, fetchedPreviousManager, formData.manager, setFormData, formData]);
+  }, [isLoadingPreviousManager, fetchedPreviousManager, hasInteracted, setFormData, formData]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -57,6 +58,7 @@ export default function ManagerScreen({ onNext, onBack, formData, setFormData, u
   }, [onNext, formData.manager, isLoadingPreviousManager]);
 
   const handleManagerChange = (manager: string) => {
+    setHasInteracted(true);
     setFormData({
       ...formData,
       manager

--- a/src/components/screens/ManagerScreen.tsx
+++ b/src/components/screens/ManagerScreen.tsx
@@ -29,7 +29,11 @@ export default function ManagerScreen({ onNext, onBack, formData, setFormData, u
   }, [userId, currentWeekNumber, currentYear]);
 
   useEffect(() => {
-    if (!isLoadingPreviousManager && !formData.manager && fetchedPreviousManager) {
+    if (
+      !isLoadingPreviousManager &&
+      (formData.manager === undefined || formData.manager === null) &&
+      fetchedPreviousManager
+    ) {
       setFormData({
         ...formData,
         manager: fetchedPreviousManager


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Only auto-fill the previous manager if formData.manager is null or undefined, preventing unintended overwrites for other falsey values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the manager field to prevent unintended overwriting when the value is an empty string or other falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->