### PR TITLE
feat: leader board longest streaks and fastest submissions for the week

### DIFF
--- a/docs/leaderboard-plan.md
+++ b/docs/leaderboard-plan.md
@@ -1,0 +1,101 @@
+# Leaderboard Feature Plan
+
+## Overview
+
+Implement a Duolingo-style leaderboard in the app, ranking users by:
+- **Longest Streaks** (consecutive weekly pulse)
+- **Top 10 Fastest Submissions** (users who submit the fastest after a weekly pulse open)
+
+**Privacy:**  
+Leaderboard will use real user stats, but will not display real emails or sensitive information. Usernames will be anonymized (e.g., display name, generated handle, or masked email).
+
+---
+
+## Goals
+
+- Motivate users by showing their rank among peers.
+- Encourage healthy competition.
+- Protect user privacy by not exposing real emails or sensitive data.
+
+---
+
+## Data Requirements
+
+- **User Identifier:** Anonymized (e.g., display name, generated username, or masked email).
+- **Avatar:** Optional, can use a default or generated avatar.
+- **Streak Count:** For longest streaks leaderboard.
+- **Submission Time:** For fastest submission leaderboard.
+- **Current User Highlight:** Clearly indicate the current user's position, even if not in the top 10.
+
+---
+
+## UI/UX
+
+- Duolingo-style vertical leaderboard.
+- Show top 10 users (configurable).
+- Highlight top 3 with special icons/colors.
+- Show current user's rank and stats, even if outside top 10.
+- Optionally, allow toggling between "Longest Streaks" and "Fastest Submissions."
+
+---
+
+## Backend/API
+
+- Endpoint to fetch leaderboard data:
+  - `/api/leaderboard?type=streaks`
+  - `/api/leaderboard?type=fastest`
+- Endpoint returns:
+  - List of anonymized users with stats.
+  - Current user's rank and stats.
+
+### Longest Streak Calculation Logic
+
+- **Current Week Determination:**
+  - The backend uses the same logic as the frontend (`getMostRecentThursdayWeek`) to determine the "current week" for streak calculations. This ensures consistency across the app.
+- **Streak Calculation:**
+  - For each user, fetch all their submissions for the current year.
+  - Build a set of all weeks in the current year up to and including the current week.
+  - Starting from the current week and moving backwards, count consecutive weeks where the user has a submission.
+  - The count stops at the first week with no submission, giving the user's current streak.
+- **Leaderboard Construction:**
+  - All users are ranked by their streak (descending), then by name (ascending).
+  - The top 10 users are included in the leaderboard response.
+  - The current user is always included in the response (marked with `isCurrentUser: true`), even if not in the top 10, and is not duplicated if already present.
+
+---
+
+## Privacy Considerations
+
+- Never expose real emails or sensitive identifiers.
+- Use display names, generated usernames, or masked emails (e.g., `j***@gmail.com`).
+- Optionally, allow users to opt out of appearing on the leaderboard.
+
+---
+
+## Implementation Steps
+
+1. **Design Data Model:**  
+   Update user model to support anonymized display names if needed.
+
+2. **Backend Logic:**  
+   - Calculate streaks and fastest submissions as described above.
+   - Build API endpoints to serve leaderboard data.
+
+3. **Frontend:**  
+   - Create leaderboard UI component/page.
+   - Fetch and display leaderboard data.
+   - Highlight current user.
+
+4. **Testing:**  
+   - Ensure privacy is maintained.
+   - Test with various user data scenarios.
+
+---
+
+## Future Enhancements
+
+- Add weekly/monthly leaderboards.
+- Add badges or rewards for top performers.
+- Allow users to customize their display name/avatar.
+
+--- 

--- a/src/app/(authenticated)/leaderboard/layout.tsx
+++ b/src/app/(authenticated)/leaderboard/layout.tsx
@@ -1,0 +1,28 @@
+import { createClient } from '@/utils/supabase/server'
+import { redirect } from 'next/navigation'
+import { Sidebar } from '@/components/Sidebar'
+
+export default async function LeaderBoardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] h-full">
+      <Sidebar pathname="/leaderboard" />
+      {/* Main Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="container mx-auto py-8 px-6">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/src/app/(authenticated)/leaderboard/page.tsx
+++ b/src/app/(authenticated)/leaderboard/page.tsx
@@ -11,6 +11,7 @@ interface LeaderboardEntry {
   name: string;
   streak?: number; 
   isCurrentUser?: boolean;
+  time?: number; // Add this to match potential API response properties
 }
 
 type LeaderboardType = "streaks" | "fastest";
@@ -69,14 +70,6 @@ const now = new Date();
 const currentYear = now.getFullYear();
 const currentWeek = getMostRecentThursdayWeek();
 
-// Define a type for leaderboard API response
-interface LeaderboardApiEntry {
-  id: string;
-  name: string;
-  streak?: number;
-  isCurrentUser?: boolean;
-}
-
 export default function LeaderboardPage() {
   const [tab, setTab] = useState<LeaderboardType>("streaks");
   const [data, setData] = useState<LeaderboardEntry[]>(mockLeaderboard[tab]);
@@ -97,7 +90,7 @@ export default function LeaderboardPage() {
         const json = await res.json();
         if (!ignore && json.leaderboard) {
           setData(
-            (json.leaderboard as LeaderboardApiEntry[]).map((entry) =>
+            (json.leaderboard as LeaderboardEntry[]).map((entry) =>
               tab === "streaks"
                 ? { ...entry, streak: entry.streak }
                 : { ...entry }

--- a/src/app/(authenticated)/leaderboard/page.tsx
+++ b/src/app/(authenticated)/leaderboard/page.tsx
@@ -9,10 +9,8 @@ import { getMostRecentThursdayWeek } from '@/lib/utils/date';
 interface LeaderboardEntry {
   id: string;
   name: string;
-  streak?: number; // for real data
-  score?: number; // for mock data
+  streak?: number; 
   isCurrentUser?: boolean;
-  time?: number; // for fastest tab
 }
 
 type LeaderboardType = "streaks" | "fastest";
@@ -27,12 +25,12 @@ const mockLeaderboard: Record<LeaderboardType, LeaderboardEntry[]> = {
     // { id: "5", name: "CleverFox", streak: 14, isCurrentUser: true }, // Uncomment to test user in list
   ],
   fastest: [
-    { id: "2", name: "BraveTiger", time: 12 },
-    { id: "1", name: "SunnyLion", time: 15 },
-    { id: "3", name: "WiseOwl", time: 20 },
-    { id: "4", name: "MightyBear", time: 22 },
+    { id: "2", name: "BraveTiger" },
+    { id: "1", name: "SunnyLion" },
+    { id: "3", name: "WiseOwl" },
+    { id: "4", name: "MightyBear" },
     // ...more users
-    // { id: "5", name: "CleverFox", time: 18, isCurrentUser: true }, // Uncomment to test user in list
+    // { id: "5", name: "CleverFox", isCurrentUser: true }, // Uncomment to test user in list
   ],
 };
 
@@ -76,7 +74,6 @@ interface LeaderboardApiEntry {
   id: string;
   name: string;
   streak?: number;
-  time?: number;
   isCurrentUser?: boolean;
 }
 
@@ -103,7 +100,7 @@ export default function LeaderboardPage() {
             (json.leaderboard as LeaderboardApiEntry[]).map((entry) =>
               tab === "streaks"
                 ? { ...entry, streak: entry.streak }
-                : { ...entry, time: entry.time }
+                : { ...entry }
             )
           );
         }

--- a/src/app/(authenticated)/leaderboard/page.tsx
+++ b/src/app/(authenticated)/leaderboard/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import clsx from "clsx";
+import { motion, AnimatePresence } from "framer-motion";
+import { Rocket } from "lucide-react";
+import { getMostRecentThursdayWeek } from '@/lib/utils/date';
+
+// Types
+interface LeaderboardEntry {
+  id: string;
+  name: string;
+  streak?: number; // for real data
+  score?: number; // for mock data
+  isCurrentUser?: boolean;
+  time?: number; // for fastest tab
+}
+
+type LeaderboardType = "streaks" | "fastest";
+
+const mockLeaderboard: Record<LeaderboardType, LeaderboardEntry[]> = {
+  streaks: [
+    { id: "1", name: "SunnyLion", streak: 21 },
+    { id: "2", name: "BraveTiger", streak: 19 },
+    { id: "3", name: "WiseOwl", streak: 18 },
+    { id: "4", name: "MightyBear", streak: 15 },
+    // ...more users
+    // { id: "5", name: "CleverFox", streak: 14, isCurrentUser: true }, // Uncomment to test user in list
+  ],
+  fastest: [
+    { id: "2", name: "BraveTiger", time: 12 },
+    { id: "1", name: "SunnyLion", time: 15 },
+    { id: "3", name: "WiseOwl", time: 20 },
+    { id: "4", name: "MightyBear", time: 22 },
+    // ...more users
+    // { id: "5", name: "CleverFox", time: 18, isCurrentUser: true }, // Uncomment to test user in list
+  ],
+};
+
+// Simulate current user stats if not in the list
+const currentUser: LeaderboardEntry = {
+  id: "5",
+  name: "CleverFox",
+  streak: 14,
+  isCurrentUser: true,
+};
+
+const TABS = [
+  { key: "streaks" as LeaderboardType, label: "Longest Streaks" },
+  { key: "fastest" as LeaderboardType, label: "Fastest Submissions" },
+];
+
+
+function getAvatarUrl(name: string) {
+  // Use DiceBear bottts style for playful avatars
+  return `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(name)}`;
+}
+
+const inspireMessages = [
+  "Keep going! Your streak could be next!",
+  "You're on your way to the top!",
+  "Every day is a new chance to climb the board!",
+  "Consistency is key. You got this!",
+  "Champions started just like you!",
+];
+
+function getInspireMessage() {
+  return inspireMessages[Math.floor(Math.random() * inspireMessages.length)];
+}
+
+const now = new Date();
+const currentYear = now.getFullYear();
+const currentWeek = getMostRecentThursdayWeek();
+
+// Define a type for leaderboard API response
+interface LeaderboardApiEntry {
+  id: string;
+  name: string;
+  streak?: number;
+  time?: number;
+  isCurrentUser?: boolean;
+}
+
+export default function LeaderboardPage() {
+  const [tab, setTab] = useState<LeaderboardType>("streaks");
+  const [data, setData] = useState<LeaderboardEntry[]>(mockLeaderboard[tab]);
+  const [inspire, setInspire] = useState(getInspireMessage());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+    async function fetchLeaderboard() {
+      setLoading(true);
+      setError(null);
+      try {
+        let url = "/api/leaderboard";
+        if (tab === "fastest") url += "?type=fastest";
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("Failed to fetch leaderboard");
+        const json = await res.json();
+        if (!ignore && json.leaderboard) {
+          setData(
+            (json.leaderboard as LeaderboardApiEntry[]).map((entry) =>
+              tab === "streaks"
+                ? { ...entry, streak: entry.streak }
+                : { ...entry, time: entry.time }
+            )
+          );
+        }
+      } catch {
+        setError("Could not load leaderboard. Showing mock data.");
+        setData(mockLeaderboard[tab]);
+      } finally {
+        setLoading(false);
+      }
+      setInspire(getInspireMessage());
+    }
+    fetchLeaderboard();
+    return () => {
+      ignore = true;
+    };
+  }, [tab]);
+
+  // Check if current user is in the list
+  const userInList = data.some((u) => u.isCurrentUser);
+
+  // Filter out users with 0 streaks for the streaks tab
+  const filteredData = tab === "streaks"
+    ? data.filter(user => (user.streak ?? 0) > 0)
+    : data;
+
+  return (
+    <>
+      <h1 className="text-3xl font-extrabold mb-6 text-blue-700 drop-shadow text-center w-full">Leaderboard</h1>
+      <div className="flex gap-4 mb-8 justify-center">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            className={clsx(
+              "px-6 py-2 rounded-full font-semibold transition",
+              tab === t.key
+                ? "bg-blue-600 text-white shadow-lg scale-105"
+                : "bg-white text-blue-700 border border-blue-300 hover:bg-blue-50"
+            )}
+            onClick={() => setTab(t.key)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-col items-center w-full">
+        {tab === "fastest" && (
+          <div className="text-base font-bold text-blue-700 mb-4 text-center">
+            Fastest Submissions for <span className="text-yellow-500">Week {currentWeek}, {currentYear}</span>
+          </div>
+        )}
+        <section className="w-full max-w-xl bg-gradient-to-br from-blue-50 to-yellow-50 rounded-2xl shadow-2xl p-6 mx-auto">
+          {loading && <div className="text-blue-400 text-center py-4">Loading...</div>}
+          {error && <div className="text-yellow-600 text-center py-2">{error}</div>}
+          {tab === "fastest" && data.length === 0 ? (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.5 }}
+              className="flex flex-col items-center justify-center py-10"
+            >
+              <span className="mb-4 animate-bounce">
+                <Rocket className="w-14 h-14 text-yellow-400 drop-shadow-lg" />
+              </span>
+              <div className="text-2xl font-extrabold text-blue-700 mb-2 text-center">
+                No submissions yet for <span className="text-yellow-500">Week {currentWeek}, {currentYear}</span>
+              </div>
+              <div className="text-blue-500 text-lg font-semibold mb-2 text-center">
+                Be the first to submit and claim the <span className="text-yellow-500">#1</span> spot!
+              </div>
+              <div className="text-yellow-600 text-sm italic text-center mt-2">
+                Early birds get the glory. Your streak could start here!
+              </div>
+            </motion.div>
+          ) : (
+            <ol className="space-y-4">
+              <AnimatePresence>
+                {filteredData.map((user: LeaderboardEntry, idx: number) => (
+                  <motion.li
+                    key={user.id}
+                    initial={{ opacity: 0, y: 30 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 30 }}
+                    transition={{ duration: 0.4, delay: idx * 0.07 }}
+                    className={clsx(
+                      "flex items-center gap-4 p-3 rounded-xl transition-all bg-white/90",
+                      idx === 0 && "border-4 border-yellow-400",
+                      idx === 1 && "border-4 border-gray-400",
+                      idx === 2 && "border-4 border-orange-400",
+                      idx < 3 && "font-bold text-lg"
+                    )}
+                  >
+                    <span className="w-8 text-center flex justify-center items-center">
+                      {idx < 3 ? (
+                        <span
+                          className="inline-block w-7 h-7 rounded-full flex items-center justify-center"
+                          style={{
+                            background:
+                              idx === 0
+                                ? "#FFD700"
+                                : idx === 1
+                                ? "#C0C0C0"
+                                : "#CD7F32",
+                            color: "#fff",
+                          }}
+                          title={idx === 0 ? "Gold" : idx === 1 ? "Silver" : "Bronze"}
+                        >
+                          <span className="font-bold text-lg">{idx + 1}</span>
+                        </span>
+                      ) : (
+                        <span className="text-blue-400 font-bold">{idx + 1}</span>
+                      )}
+                    </span>
+                    <span className="w-10 h-10 rounded-full border-2 border-blue-300 bg-white flex items-center justify-center overflow-hidden">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={getAvatarUrl(user.name)}
+                        alt={user.name}
+                        width={40}
+                        height={40}
+                        className="rounded-full"
+                        loading={idx < 3 ? "eager" : "lazy"}
+                      />
+                    </span>
+                    <span className="flex-1 truncate font-semibold text-blue-800">
+                      {user.name}
+                      {user.isCurrentUser && (
+                        <motion.span
+                          className="ml-2 px-2 py-0.5 text-xs bg-yellow-200 rounded-full text-yellow-800 font-bold"
+                          animate={{ scale: [1, 1.15, 1] }}
+                          transition={{ repeat: Infinity, duration: 1.2 }}
+                        >
+                          You
+                        </motion.span>
+                      )}
+                    </span>
+                    <span className="text-xl font-mono text-blue-700">
+                      {tab === "streaks"
+                        ? `${user.streak ?? 0} ${user.streak === 1 ? "week" : "weeks"} 🔥`
+                        : `#${idx + 1}`}
+                    </span>
+                  </motion.li>
+                ))}
+              </AnimatePresence>
+            </ol>
+          )}
+        </section>
+        {tab === "fastest" && (
+          <div className="text-xs text-blue-400 text-center mt-2">
+            {/* No time info needed for fastest submissions */}
+          </div>
+        )}
+        {!userInList && (
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5, duration: 0.7 }}
+            className="relative z-10 w-full max-w-md mt-8"
+          >
+            <div className="bg-white/95 border-2 border-yellow-300 rounded-2xl shadow-xl p-5 flex items-center gap-4">
+              <span className="w-12 h-12 rounded-full border-2 border-blue-200 bg-white flex items-center justify-center overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={getAvatarUrl(currentUser.name)}
+                  alt={currentUser.name}
+                  width={48}
+                  height={48}
+                  className="rounded-full"
+                  loading="lazy"
+                />
+              </span>
+              <div className="flex-1">
+                <div className="font-bold text-blue-700 text-lg">{currentUser.name} <span className="ml-2 px-2 py-0.5 text-xs bg-yellow-200 rounded-full text-yellow-800 font-bold">You</span></div>
+                <div className="text-blue-500 text-sm mt-1">
+                  {tab === "streaks"
+                    ? `${currentUser.streak ?? 0} weeks 🔥`
+                    : `Fastest submission`}
+                </div>
+                <div className="text-yellow-600 text-xs mt-2 italic">{inspire}</div>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </div>
+      <p className="mt-8 text-blue-400 text-sm text-center">* Avatars are generated and usernames are anonymized for privacy.</p>
+    </>
+  );
+} 

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+import { getMostRecentThursdayWeek } from '@/lib/utils/date';
+
+interface User {
+  id: string;
+  name: string | null;
+  email: string;
+}
+
+interface Submission {
+  user_id: string;
+  year: number;
+  week_number: number;
+  submitted_at: string;
+  form_completion_time?: number;
+}
+
+interface Week {
+  year: number;
+  week_number: number;
+}
+
+interface StreakLeaderboardEntry {
+  id: string;
+  name: string;
+  streak: number;
+  isCurrentUser?: boolean;
+}
+
+interface FastestLeaderboardEntry {
+  id: string;
+  name: string;
+  isCurrentUser?: boolean;
+}
+
+function maskEmail(email: string): string {
+  // Mask email for privacy (e.g., j***@gmail.com)
+  const [name, domain] = email.split('@');
+  if (!name || !domain) return email;
+  return name[0] + '***@' + domain;
+}
+
+function getDisplayName(user: User): string {
+  if (user.name && user.name.trim() !== '') return user.name;
+  return maskEmail(user.email);
+}
+
+function calculateMaxStreak(submissions: Submission[], allWeeks: Week[], currentWeek: number): number {
+  const submittedWeeks = new Set(submissions.map(s => s.week_number));
+  const sortedWeeks = allWeeks
+    .filter(w => w.week_number <= currentWeek)
+    .sort((a, b) => a.week_number - b.week_number); // ascending
+
+  let maxStreak = 0;
+  let currentStreak = 0;
+  for (let i = 0; i < sortedWeeks.length; i++) {
+    const weekNum = sortedWeeks[i].week_number;
+    if (submittedWeeks.has(weekNum)) {
+      currentStreak++;
+      maxStreak = Math.max(maxStreak, currentStreak);
+    } else {
+      currentStreak = 0;
+    }
+  }
+  return maxStreak;
+}
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type') || 'streaks';
+
+  // Get current user from session
+  const { data: { user: currentUser } } = await supabase.auth.getUser();
+  const currentUserId = currentUser?.id;
+
+  // Get all users (including admins)
+  const { data: users, error: usersError } = await supabase
+    .from('users')
+    .select('id, name, email, is_admin');
+  if (usersError) {
+    return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 });
+  }
+
+  // Get current year and all weeks for the year
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const { data: allWeeks, error: weeksError } = await supabase
+    .from('weeks')
+    .select('year, week_number')
+    .eq('year', currentYear)
+    .order('week_number', { ascending: true });
+  if (weeksError) {
+    return NextResponse.json({ error: 'Failed to fetch weeks' }, { status: 500 });
+  }
+
+  // Use getMostRecentThursdayWeek for current week
+  const currentWeek = getMostRecentThursdayWeek();
+
+  if (type === 'fastest') {
+    // Get all submissions for the current week
+    const { data: submissions, error: submissionsError } = await supabase
+      .from('submissions')
+      .select('user_id, year, week_number, submitted_at')
+      .eq('year', currentYear)
+      .eq('week_number', currentWeek)
+      .not('submitted_at', 'is', null);
+    if (submissionsError) {
+      return NextResponse.json({ error: 'Failed to fetch submissions' }, { status: 500 });
+    }
+
+    // Map user_id to user
+    const userMap = Object.fromEntries(users.map((u: User) => [u.id, u]));
+
+    // Sort by submitted_at (earliest first)
+    const leaderboard: FastestLeaderboardEntry[] = submissions
+      .filter(s => userMap[s.user_id])
+      .sort((a, b) => new Date(a.submitted_at).getTime() - new Date(b.submitted_at).getTime())
+      .map(s => ({
+        id: s.user_id,
+        name: getDisplayName(userMap[s.user_id]),
+        isCurrentUser: s.user_id === currentUserId,
+      }));
+
+    // Only top 10, but always include current user if they submitted
+    const top = leaderboard.slice(0, 10);
+    const currentUserEntry = leaderboard.find(e => e.id === currentUserId);
+    if (currentUserEntry && !top.some(e => e.id === currentUserId)) {
+      top.push(currentUserEntry);
+    }
+
+    return NextResponse.json({ leaderboard: top });
+  }
+
+  // Get all submissions for the current year
+  const { data: submissions, error: submissionsError } = await supabase
+    .from('submissions')
+    .select('user_id, year, week_number, submitted_at')
+    .eq('year', currentYear);
+  if (submissionsError) {
+    return NextResponse.json({ error: 'Failed to fetch submissions' }, { status: 500 });
+  }
+
+  // Calculate streaks for each user
+  const leaderboard: StreakLeaderboardEntry[] = users.map((user: User) => {
+    const userSubs = submissions.filter(s => s.user_id === user.id);
+    const streak = calculateMaxStreak(userSubs, allWeeks, currentWeek);
+    return {
+      id: user.id,
+      name: getDisplayName(user),
+      streak,
+      isCurrentUser: user.id === currentUserId,
+    };
+  });
+
+  // Sort by streak descending, then by name
+  leaderboard.sort((a, b) => b.streak - a.streak || a.name.localeCompare(b.name));
+
+  // Only top 10, but always include current user if not in top
+  const top = leaderboard.slice(0, 10);
+  const currentUserEntry = leaderboard.find(e => e.id === currentUserId);
+  if (currentUserEntry && !top.some(e => e.id === currentUserId)) {
+    top.push(currentUserEntry);
+  }
+
+  return NextResponse.json({ leaderboard: top });
+} 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
       const { data: { user } } = await supabase.auth.getUser()
       const email = user?.email
 
-      //Check if the email is from your company domain
+      // Check if the email is from your company domain
       const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
       if (!email || !email.endsWith(companyDomain)) {
         // Sign out the user

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -17,13 +17,13 @@ export async function GET(request: NextRequest) {
       const email = user?.email
 
       // Check if the email is from your company domain
-      const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
-      if (!email || !email.endsWith(companyDomain)) {
-        // Sign out the user
-        await supabase.auth.signOut()
-        // Redirect to an error page or login with a message
-        return NextResponse.redirect(`${origin}/auth/invalid-domain`)
-      }
+      // const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+      // if (!email || !email.endsWith(companyDomain)) {
+      //   // Sign out the user
+      //   await supabase.auth.signOut()
+      //   // Redirect to an error page or login with a message
+      //   return NextResponse.redirect(`${origin}/auth/invalid-domain`)
+      // }
 
       const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
       const isLocalEnv = process.env.NODE_ENV === 'development'

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -16,14 +16,14 @@ export async function GET(request: NextRequest) {
       const { data: { user } } = await supabase.auth.getUser()
       const email = user?.email
 
-      // Check if the email is from your company domain
-      // const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
-      // if (!email || !email.endsWith(companyDomain)) {
-      //   // Sign out the user
-      //   await supabase.auth.signOut()
-      //   // Redirect to an error page or login with a message
-      //   return NextResponse.redirect(`${origin}/auth/invalid-domain`)
-      // }
+      //Check if the email is from your company domain
+      const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+      if (!email || !email.endsWith(companyDomain)) {
+        // Sign out the user
+        await supabase.auth.signOut()
+        // Redirect to an error page or login with a message
+        return NextResponse.redirect(`${origin}/auth/invalid-domain`)
+      }
 
       const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
       const isLocalEnv = process.env.NODE_ENV === 'development'

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { User, History } from 'lucide-react'
+import { User, History, Trophy } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 export type SidebarItem = {
@@ -18,6 +18,11 @@ const sidebarItems: SidebarItem[] = [
     title: 'History',
     href: '/history',
     icon: <History className="w-5 h-5" />
+  },
+  {
+    title: 'Leaderboard',
+    href: '/leaderboard',
+    icon: <Trophy className="w-5 h-5 text-yellow-500" />
   }
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Add a Duolingo-style leaderboard feature showcasing longest weekly streaks and fastest weekly submissions with a protected authenticated route and a Supabase-powered API.

New Features:
- Introduce a leaderboard page with tabs for longest streaks and fastest submissions.
- Implement a Next.js API endpoint to fetch streak and fastest submission data from Supabase.
- Add an authenticated layout for the leaderboard route to enforce login protection.

Enhancements:
- Add a Trophy icon and Sidebar link to the leaderboard.
- Display dynamic avatars, animated rankings, and motivational messages in the leaderboard UI.
- Fallback to mock data and show the current user’s position when real data fails or the user is outside the top 10.

Documentation:
- Add a detailed design and implementation plan for the leaderboard feature in docs/leaderboard-plan.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Duolingo-style leaderboard with two views: "Longest Streaks" and "Fastest Submissions."
  - Added a dedicated leaderboard page with animated UI, user avatars, and special highlights for top users.
  - Implemented a new sidebar navigation item for easy access to the leaderboard.
  - Users can view their own rank and stats, even if not in the top 10.

- **Documentation**
  - Added a comprehensive plan outlining the leaderboard feature, privacy considerations, and future enhancement ideas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->