### PR TITLE
fix: add logic if users same streak

### DIFF
--- a/src/app/(authenticated)/leaderboard/page.tsx
+++ b/src/app/(authenticated)/leaderboard/page.tsx
@@ -145,7 +145,11 @@ export default function LeaderboardPage() {
           </div>
         )}
         <section className="w-full max-w-xl bg-gradient-to-br from-blue-50 to-yellow-50 rounded-2xl shadow-2xl p-6 mx-auto">
-          {loading && <div className="text-blue-400 text-center py-4">Loading...</div>}
+          {loading && (
+            <div className="flex flex-col items-center justify-center py-4">
+              <span className="inline-block w-8 h-8 border-4 border-blue-300 border-t-blue-600 rounded-full animate-spin mb-2"></span>
+            </div>
+          )}
           {error && <div className="text-yellow-600 text-center py-2">{error}</div>}
           {tab === "fastest" && data.length === 0 ? (
             <motion.div
@@ -277,7 +281,12 @@ export default function LeaderboardPage() {
           </motion.div>
         )}
       </div>
-      <p className="mt-8 text-blue-400 text-sm text-center">* Avatars are generated and usernames are anonymized for privacy.</p>
+      {tab === "streaks" && (
+        <p className="mt-6 text-blue-500 text-xs text-center max-w-xl mx-auto">
+          <strong>Tip:</strong> If multiple users have the same streak, the leaderboard ranks them by who submitted earliest this week. If no one submitted this week, it uses last week&rsquo;s submission time. If there is still a tie, names are sorted alphabetically.
+        </p>
+      )}
+      <p className="mt-8 text-blue-400 text-sm text-center">* Avatars are generated and email addresses are anonymized for privacy.</p>
     </>
   );
 } 

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -175,10 +175,10 @@ export async function GET(request: Request) {
 
     // Fallback: sort by previous week's submission time (with week 1 → 52 rollover)
     let previousWeek = currentWeek - 1;
-    let previousYear = currentYear;
+    // let previousYear = currentYear;
     if (previousWeek === 0) {
       previousWeek = 52;
-      previousYear = currentYear - 1;
+      // previousYear = currentYear - 1;
     }
     const aPrev = submissions.find(
       s => s.user_id === a.id && s.week_number === previousWeek /* && s.year === previousYear */

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -173,14 +173,18 @@ export async function GET(request: Request) {
     if (aLatest) return -1; // a submitted, b did not
     if (bLatest) return 1;  // b submitted, a did not
 
-    // Fallback: sort by previous week's submission time
-    // This keeps the leaderboard fresh and rewards recent activity if no one submitted this week
-    const previousWeek = currentWeek - 1;
+    // Fallback: sort by previous week's submission time (with week 1 → 52 rollover)
+    let previousWeek = currentWeek - 1;
+    let previousYear = currentYear;
+    if (previousWeek === 0) {
+      previousWeek = 52;
+      previousYear = currentYear - 1;
+    }
     const aPrev = submissions.find(
-      s => s.user_id === a.id && s.week_number === previousWeek
+      s => s.user_id === a.id && s.week_number === previousWeek /* && s.year === previousYear */
     );
     const bPrev = submissions.find(
-      s => s.user_id === b.id && s.week_number === previousWeek
+      s => s.user_id === b.id && s.week_number === previousWeek /* && s.year === previousYear */
     );
 
     if (aPrev && bPrev) {

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -42,7 +42,7 @@ function maskEmail(email: string): string {
 }
 
 function getDisplayName(user: User): string {
-  if (user.name && user.name.trim() !== '') return user.name;
+  // if (user.name && user.name.trim() !== '') return user.name;
   return maskEmail(user.email);
 }
 
@@ -173,7 +173,24 @@ export async function GET(request: Request) {
     if (aLatest) return -1; // a submitted, b did not
     if (bLatest) return 1;  // b submitted, a did not
 
-    // Fallback: alphabetical
+    // Fallback: sort by previous week's submission time
+    // This keeps the leaderboard fresh and rewards recent activity if no one submitted this week
+    const previousWeek = currentWeek - 1;
+    const aPrev = submissions.find(
+      s => s.user_id === a.id && s.week_number === previousWeek
+    );
+    const bPrev = submissions.find(
+      s => s.user_id === b.id && s.week_number === previousWeek
+    );
+
+    if (aPrev && bPrev) {
+      // Earlier submission ranks higher
+      return new Date(aPrev.submitted_at).getTime() - new Date(bPrev.submitted_at).getTime();
+    }
+    if (aPrev) return -1; // a submitted last week, b did not
+    if (bPrev) return 1;  // b submitted last week, a did not
+
+    // Still fallback: alphabetical
     return a.name.localeCompare(b.name);
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Implement tie-breaking logic for equal streaks, standardize email masking, improve loading UI, and update user guidance and privacy note

Enhancements:
- Break streak ties by earliest submission time this week, then last week, then alphabetically
- Always mask user emails for display names regardless of username presence
- Replace textual “Loading...” indicator with a spinner during data fetch

Documentation:
- Add a tip under the streaks tab explaining the tie-break logic
- Update privacy note to specify that email addresses (instead of usernames) are anonymized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a visually styled spinning loader to indicate when leaderboard data is loading.
  - Introduced a tip explaining tiebreaker rules for the "streaks" leaderboard tab.

- **Bug Fixes**
  - Improved sorting for the streak leaderboard by considering previous week's submission times for more accurate ranking.

- **Documentation**
  - Updated the leaderboard footer note to clarify that email addresses, not usernames, are anonymized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->