### PR TITLE
fix: add temporary maxDuration

### DIFF
--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -2,6 +2,8 @@ import { createClient } from '@/utils/supabase/server';
 import { NextResponse } from 'next/server';
 import { getMostRecentThursdayWeek } from '@/lib/utils/date';
 
+export const maxDuration = 300; // 5 minutes
+
 export async function GET(request: Request) {
   // Authenticate using CRON_SECRET
   const authHeader = request.headers.get('authorization');


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a temporary `maxDuration` constant set to 300 seconds for cron reminders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting that defines a maximum duration of 5 minutes for certain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->