### PR TITLE
fix: fix weekly filter

### DIFF
--- a/src/app/(authenticated)/history/page.tsx
+++ b/src/app/(authenticated)/history/page.tsx
@@ -98,7 +98,11 @@ export default async function HistoryPage({
       label: `Week ${w.week_number}, ${w.year}`,
       week_number: w.week_number,
       year: w.year,
-    }));
+    }))
+    .sort((a, b) => {
+      if (a.year !== b.year) return b.year - a.year;
+      return b.week_number - a.week_number;
+    });
 
   // Determine selected week
   const defaultWeekValue = weekOptions.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 

--- a/src/components/WeekFilter.tsx
+++ b/src/components/WeekFilter.tsx
@@ -22,15 +22,10 @@ export function WeekFilter({ weeks }: WeekFilterProps) {
   
   const currentYear = new Date().getFullYear();
   const currentWeek = getMostRecentThursdayWeek();
-  
-  // Sort weeks descending (latest first)
-  const sortedWeeks = [...weeks].sort((a, b) => {
-    if (a.year !== b.year) return b.year - a.year;
-    return b.week_number - a.week_number;
-  });
 
-  const defaultWeekValue = sortedWeeks.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 
-    (sortedWeeks.length > 0 ? sortedWeeks[0].value : '');
+  // Use weeks as-is, assume already sorted by parent
+  const defaultWeekValue = weeks.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 
+    (weeks.length > 0 ? weeks[0].value : '');
   
   const currentWeekValue = searchParams.get('week') || defaultWeekValue;
 
@@ -47,7 +42,7 @@ export function WeekFilter({ weeks }: WeekFilterProps) {
           <SelectValue placeholder="Filter by week" />
         </SelectTrigger>
         <SelectContent className="max-h-60 overflow-y-auto">
-          {sortedWeeks.map(option => (
+          {weeks.map(option => (
             <SelectItem
               key={option.value}
               value={option.value}

--- a/src/components/WeekFilter.tsx
+++ b/src/components/WeekFilter.tsx
@@ -23,8 +23,14 @@ export function WeekFilter({ weeks }: WeekFilterProps) {
   const currentYear = new Date().getFullYear();
   const currentWeek = getMostRecentThursdayWeek();
   
-  const defaultWeekValue = weeks.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 
-    (weeks.length > 0 ? weeks[weeks.length - 1].value : '');
+  // Sort weeks descending (latest first)
+  const sortedWeeks = [...weeks].sort((a, b) => {
+    if (a.year !== b.year) return b.year - a.year;
+    return b.week_number - a.week_number;
+  });
+
+  const defaultWeekValue = sortedWeeks.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 
+    (sortedWeeks.length > 0 ? sortedWeeks[0].value : '');
   
   const currentWeekValue = searchParams.get('week') || defaultWeekValue;
 
@@ -40,8 +46,8 @@ export function WeekFilter({ weeks }: WeekFilterProps) {
         <SelectTrigger className="w-full">
           <SelectValue placeholder="Filter by week" />
         </SelectTrigger>
-        <SelectContent>
-          {weeks.map(option => (
+        <SelectContent className="max-h-60 overflow-y-auto">
+          {sortedWeeks.map(option => (
             <SelectItem
               key={option.value}
               value={option.value}


### PR DESCRIPTION
## Summary by Sourcery

Sort the weeks descending for both default selection and list rendering, and make the week dropdown scrollable.

Bug Fixes:
- Fix default week selection logic when the week list is unsorted.

Enhancements:
- Sort week items in descending order by year and week number.
- Add max-height and overflow-y-auto to the dropdown for a scrollable week list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Weeks in the filter dropdown are now displayed in descending chronological order for easier selection.
- **Style**
  - The week selection dropdown now has a fixed maximum height with vertical scrolling for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->