### PR TITLE
fix: admin can update user name

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -95,7 +95,8 @@ export default function UsersPage() {
   };
 
   const handleNameSave = async (user: User) => {
-    if (editingName.trim() === user.name) {
+    const newName = editingName.trim();
+    if (newName === '' || newName === user.name) {
       setEditingUserId(null);
       return;
     }
@@ -104,7 +105,7 @@ export default function UsersPage() {
       const response = await fetch('/api/admin/users', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: user.id, name: editingName.trim() }),
+        body: JSON.stringify({ userId: user.id, name: newName }),
       });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Failed to update name');
@@ -209,16 +210,17 @@ export default function UsersPage() {
                       {editingUserId === user.id ? (
                         <div className="flex items-center gap-2">
                           <input
+                            id={`edit-user-name-${user.id}`}
+                            name={`edit-user-name-${user.id}`}
                             type="text"
                             value={editingName}
                             onChange={handleNameChange}
-                            onBlur={() => handleNameSave(user)}
                             onKeyDown={(e) => handleNameInputKeyDown(e, user)}
                             className="border rounded px-2 py-1 w-full text-sm focus:ring-2 focus:ring-blue-500"
                             autoFocus
                             disabled={savingName}
                             aria-label="Edit user name"
-                            autoComplete="name"
+                            autoComplete="off"
                           />
                           <Button
                             size="icon"

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Upload } from 'lucide-react';
+import { ArrowLeft, Upload, Pencil, Check, X, Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import {
   Table,
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import ImportDialog from '@/components/admin/ImportDialog';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { useToast } from '@/components/ui/use-toast';
 
 interface User {
   id: string;
@@ -30,6 +32,10 @@ export default function UsersPage() {
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
+  const [editingUserId, setEditingUserId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState<string>('');
+  const [savingName, setSavingName] = useState(false);
+  const { toast } = useToast();
 
   const fetchUsers = async (search?: string) => {
     try {
@@ -76,6 +82,52 @@ export default function UsersPage() {
       fetchUsers(searchQuery);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update user');
+    }
+  };
+
+  const handleNameEdit = (user: User) => {
+    setEditingUserId(user.id);
+    setEditingName(user.name || '');
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditingName(e.target.value);
+  };
+
+  const handleNameSave = async (user: User) => {
+    if (editingName.trim() === user.name) {
+      setEditingUserId(null);
+      return;
+    }
+    setSavingName(true);
+    try {
+      const response = await fetch('/api/admin/users', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: user.id, name: editingName.trim() }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Failed to update name');
+      setEditingUserId(null);
+      fetchUsers(searchQuery);
+      toast({ title: 'Name updated', description: `User name updated successfully.`, variant: 'default' });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update name');
+      toast({ title: 'Error', description: 'Failed to update name', variant: 'destructive' });
+    } finally {
+      setSavingName(false);
+    }
+  };
+
+  const handleNameCancel = () => {
+    setEditingUserId(null);
+  };
+
+  const handleNameInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, user: User) => {
+    if (e.key === 'Enter') {
+      handleNameSave(user);
+    } else if (e.key === 'Escape') {
+      handleNameCancel();
     }
   };
 
@@ -153,7 +205,67 @@ export default function UsersPage() {
                 {users.map((user) => (
                   <TableRow key={user.id}>
                     <TableCell>{user.email}</TableCell>
-                    <TableCell>{user.name || '-'}</TableCell>
+                    <TableCell>
+                      {editingUserId === user.id ? (
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            value={editingName}
+                            onChange={handleNameChange}
+                            onBlur={() => handleNameSave(user)}
+                            onKeyDown={(e) => handleNameInputKeyDown(e, user)}
+                            className="border rounded px-2 py-1 w-full text-sm focus:ring-2 focus:ring-blue-500"
+                            autoFocus
+                            disabled={savingName}
+                            aria-label="Edit user name"
+                            autoComplete="name"
+                          />
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            onClick={() => handleNameSave(user)}
+                            disabled={savingName}
+                            aria-label="Save name"
+                          >
+                            {savingName ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <Check className="w-4 h-4 text-green-600" />
+                            )}
+                          </Button>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            onClick={handleNameCancel}
+                            disabled={savingName}
+                            aria-label="Cancel edit"
+                          >
+                            <X className="w-4 h-4 text-gray-400 hover:text-red-500 transition-colors" />
+                          </Button>
+                        </div>
+                      ) : (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              className="group cursor-pointer hover:bg-blue-50 focus:bg-blue-50 rounded px-2 py-1 inline-flex items-center gap-1 transition-colors w-full"
+                              onClick={() => handleNameEdit(user)}
+                              tabIndex={0}
+                              aria-label="Edit user name"
+                            >
+                              <span className="group-hover:underline text-left flex-1">{user.name || '-'}</span>
+                              <Pencil
+                                className="w-4 h-4 text-gray-300 group-hover:text-blue-500 group-focus:text-blue-500 transition-all opacity-0 group-hover:opacity-100 group-focus:opacity-100 scale-90 group-hover:scale-100 group-focus:scale-100"
+                                aria-hidden="true"
+                              />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent sideOffset={4}>
+                            Click to edit name
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </TableCell>
                     <TableCell>
                       {new Date(user.created_at).toLocaleDateString()}
                     </TableCell>

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -89,8 +89,13 @@ export async function PATCH(request: Request) {
     }
 
     const { userId, is_admin, name } = await request.json();
+    const trimmedName = typeof name === 'string' ? name.trim() : undefined;
 
-    if (!userId || (typeof is_admin !== 'boolean' && typeof name !== 'string')) {
+    if (
+      !userId ||
+      (typeof is_admin !== 'boolean' && typeof trimmedName !== 'string') ||
+      trimmedName === ''
+    ) {
       return NextResponse.json(
         { error: 'Invalid request body' },
         { status: 400 }
@@ -108,7 +113,7 @@ export async function PATCH(request: Request) {
     // Build update object
     const updateData: Record<string, unknown> = {};
     if (typeof is_admin === 'boolean') updateData.is_admin = is_admin;
-    if (typeof name === 'string') updateData.name = name;
+    if (typeof trimmedName === 'string' && trimmedName !== '') updateData.name = trimmedName;
 
     const { error } = await supabase
       .from('users')

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -88,9 +88,9 @@ export async function PATCH(request: Request) {
       );
     }
 
-    const { userId, is_admin } = await request.json();
+    const { userId, is_admin, name } = await request.json();
 
-    if (!userId || typeof is_admin !== 'boolean') {
+    if (!userId || (typeof is_admin !== 'boolean' && typeof name !== 'string')) {
       return NextResponse.json(
         { error: 'Invalid request body' },
         { status: 400 }
@@ -98,16 +98,21 @@ export async function PATCH(request: Request) {
     }
 
     // Don't allow users to remove their own admin status
-    if (userId === user.id && !is_admin) {
+    if (userId === user.id && is_admin === false) {
       return NextResponse.json(
         { error: 'Cannot remove your own admin status' },
         { status: 400 }
       );
     }
 
+    // Build update object
+    const updateData: Record<string, unknown> = {};
+    if (typeof is_admin === 'boolean') updateData.is_admin = is_admin;
+    if (typeof name === 'string') updateData.name = name;
+
     const { error } = await supabase
       .from('users')
-      .update({ is_admin })
+      .update(updateData)
       .eq('id', userId);
 
     if (error) {


### PR DESCRIPTION
## Summary by Sourcery

Enable inline editing of user names in the admin users page and extend the API to persist name updates.

New Features:
- Allow administrators to edit and save user names directly within the users table UI
- Extend the admin PATCH endpoint to accept and update user name alongside admin status

Enhancements:
- Add tooltips, toast notifications, and keyboard shortcuts (Enter/Escape) for a smoother name editing workflow
- Improve PATCH request validation and dynamically construct the update payload to include name changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline editing for user names directly within the users table, including keyboard navigation and accessibility support.
  - Users can now click the name field to edit, save, or cancel changes, with real-time feedback and notifications.
- **Enhancements**
  - Improved feedback with loading indicators and toast notifications during save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->