### PR TITLE
admin can filter submissions by week

### DIFF
--- a/src/app/(authenticated)/history/page.tsx
+++ b/src/app/(authenticated)/history/page.tsx
@@ -40,10 +40,15 @@ function calculateStreak(
   return streak;
 }
 
+interface HistoryPageParams {
+  week?: string;
+  year?: string;
+}
+
 export default async function HistoryPage({ 
   searchParams 
 }: { 
-  searchParams: Promise<{ week?: string }> 
+  searchParams: Promise<HistoryPageParams> 
 }) {
   const params = await searchParams;
   const supabase = await createClient()
@@ -108,8 +113,8 @@ export default async function HistoryPage({
   // Determine selected week
   const defaultWeekValue = weekOptions.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 
     (weekOptions.length > 0 ? weekOptions[weekOptions.length - 1].value : '');
-  const selectedWeekParam = params.week || defaultWeekValue;
-  const [selectedYear, selectedWeek] = selectedWeekParam.split('-').map(Number);
+  const selectedWeek = params.week ? Number(params.week) : Number((defaultWeekValue || '').split('-')[1]);
+  const selectedYear = params.year ? Number(params.year) : Number((defaultWeekValue || '').split('-')[0]);
 
   // Find the week and submission
   const week = weekOptions.find(w => w.year === selectedYear && w.week_number === selectedWeek);

--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import {
@@ -28,6 +28,19 @@ interface WeekOption {
 }
 
 export default function SubmissionsPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Submissions</h1>
+      </div>
+      <Suspense fallback={<div className="py-8 text-center">Loading submissions...</div>}>
+        <SubmissionsFilterAndTable />
+      </Suspense>
+    </div>
+  );
+}
+
+function SubmissionsFilterAndTable() {
   const [submissions, setSubmissions] = useState<WeeklyPulseSubmission[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -77,8 +90,9 @@ export default function SubmissionsPage() {
   useEffect(() => {
     if (!weeks.length) return;
     const weekParam = searchParams.get('week');
-    if (weekParam) {
-      const [year, week] = weekParam.split('-').map(Number);
+    const yearParam = searchParams.get('year');
+    if (weekParam && yearParam) {
+      const [year, week] = [Number(yearParam), Number(weekParam)];
       setSelectedWeek(week);
       setSelectedYear(year);
     }
@@ -121,10 +135,7 @@ export default function SubmissionsPage() {
   const weekOptions = weeks;
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold">Submissions</h1>
-      </div>
+    <>
       <div className="flex justify-between gap-4 w-full max-w-xl ml-auto">
         <WeekFilter weeks={weekOptions} />
         <div className="relative flex-1">
@@ -139,7 +150,7 @@ export default function SubmissionsPage() {
       </div>
       <Card>
         <CardHeader>
-          <CardTitle>Submissions</CardTitle>
+          <CardTitle>All Submissions</CardTitle>
         </CardHeader>
         <CardContent>
           <Table>
@@ -229,6 +240,6 @@ export default function SubmissionsPage() {
           }}
         />
       )}
-    </div>
+    </>
   );
 } 

--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -84,7 +84,7 @@ function SubmissionsFilterAndTable() {
       }
     }
     fetchWeeks();
-  }, [searchParams]);
+  }, []);
 
   // Update selected week if query param changes
   useEffect(() => {
@@ -92,9 +92,8 @@ function SubmissionsFilterAndTable() {
     const weekParam = searchParams.get('week');
     const yearParam = searchParams.get('year');
     if (weekParam && yearParam) {
-      const [year, week] = [Number(yearParam), Number(weekParam)];
-      setSelectedWeek(week);
-      setSelectedYear(year);
+      setSelectedWeek(Number(weekParam));
+      setSelectedYear(Number(yearParam));
     }
   }, [searchParams, weeks]);
 
@@ -115,7 +114,7 @@ function SubmissionsFilterAndTable() {
   const fetchSubmissions = async (params: URLSearchParams) => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/submissions/admin?${params}`);
+      const response = await fetch(`/api/admin/submissions?${params}`);
       const data = await response.json();
       if (!response.ok) {
         throw new Error(data.error || 'Failed to fetch submissions');

--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -52,7 +52,11 @@ function SubmissionsFilterAndTable() {
   const [selectedYear, setSelectedYear] = useState<number | null>(null);
   const searchParams = useSearchParams();
 
-  // Fetch available weeks for the selector
+  // Extract week and year params for useEffect dependencies
+  const weekParam = searchParams.get('week');
+  const yearParam = searchParams.get('year');
+
+  // Fetch available weeks for the selector (run only once on mount)
   useEffect(() => {
     async function fetchWeeks() {
       const res = await fetch('/api/admin/pulses');
@@ -66,8 +70,6 @@ function SubmissionsFilterAndTable() {
         }));
         setWeeks(weekOptions);
         // Set default week from query or getMostRecentThursdayWeek
-        const weekParam = searchParams.get('week');
-        const yearParam = searchParams.get('year');
         let defaultWeek = null;
         if (weekParam && yearParam) {
           const [year, week] = [Number(yearParam), Number(weekParam)];
@@ -84,18 +86,17 @@ function SubmissionsFilterAndTable() {
       }
     }
     fetchWeeks();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only run once on mount
 
   // Update selected week if query param changes
   useEffect(() => {
     if (!weeks.length) return;
-    const weekParam = searchParams.get('week');
-    const yearParam = searchParams.get('year');
     if (weekParam && yearParam) {
       setSelectedWeek(Number(weekParam));
       setSelectedYear(Number(yearParam));
     }
-  }, [searchParams, weeks]);
+  }, [weekParam, yearParam, weeks]);
 
   // Fetch submissions for selected week and search query
   useEffect(() => {

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -31,12 +31,16 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const email = searchParams.get('email');
     let week = searchParams.get('week');
-    const yearParam = searchParams.get('year');
-    const year = yearParam ? Number(yearParam) : new Date().getFullYear();
+    const yearStr = searchParams.get('year');
 
-    // Always filter by week: if not provided, use getMostRecentThursdayWeek
-    if (!week || week === 'all') {
-      week = String(getMostRecentThursdayWeek());
+    // derive defaults first
+    if (!week || week === 'all') week = String(getMostRecentThursdayWeek());
+    const year = yearStr ? Number(yearStr) : new Date().getFullYear();
+
+    // basic sanity checks
+    const weekNum = Number(week);
+    if (!Number.isInteger(weekNum) || weekNum < 1 || weekNum > 53 || !Number.isInteger(year)) {
+      return NextResponse.json({ error: 'Invalid week/year query parameter' }, { status: 400 });
     }
 
     const status = searchParams.get('status');
@@ -73,7 +77,7 @@ export async function GET(request: Request) {
       query = query.in('user_id', userIds);
     }
     // Always filter by week and year
-    query = query.eq('week_number', Number(week)).eq('year', year);
+    query = query.eq('week_number', weekNum).eq('year', year);
     if (status && status !== 'all') {
       query = query.eq('status', status);
     }

--- a/src/app/api/submissions/admin/route.ts
+++ b/src/app/api/submissions/admin/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import { NextResponse } from 'next/server';
+import { getMostRecentThursdayWeek } from '@/lib/utils/date';
 
 export async function GET(request: Request) {
   try {
@@ -29,7 +30,15 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const email = searchParams.get('email');
-    const week = searchParams.get('week');
+    let week = searchParams.get('week');
+    const yearParam = searchParams.get('year');
+    const year = yearParam ? Number(yearParam) : new Date().getFullYear();
+
+    // Always filter by week: if not provided, use getMostRecentThursdayWeek
+    if (!week || week === 'all') {
+      week = String(getMostRecentThursdayWeek());
+    }
+
     const status = searchParams.get('status');
 
     // Build the query
@@ -63,9 +72,8 @@ export async function GET(request: Request) {
       const userIds = usersData.map(user => user.id);
       query = query.in('user_id', userIds);
     }
-    if (week && week !== 'all') {
-      query = query.eq('week_number', Number(week));
-    }
+    // Always filter by week and year
+    query = query.eq('week_number', Number(week)).eq('year', year);
     if (status && status !== 'all') {
       query = query.eq('status', status);
     }

--- a/src/components/WeekFilter.tsx
+++ b/src/components/WeekFilter.tsx
@@ -27,11 +27,15 @@ export function WeekFilter({ weeks }: WeekFilterProps) {
   const defaultWeekValue = weeks.find(w => w.week_number === currentWeek && w.year === currentYear)?.value || 
     (weeks.length > 0 ? weeks[0].value : '');
   
-  const currentWeekValue = searchParams.get('week') || defaultWeekValue;
+  const weekParam = searchParams.get('week');
+  const yearParam = searchParams.get('year');
+  const currentWeekValue = (yearParam && weekParam) ? `${yearParam}-${weekParam}` : defaultWeekValue;
 
   const handleWeekChange = (value: string) => {
     const params = new URLSearchParams(searchParams);
-    params.set('week', value);
+    const [year, week] = value.split('-');
+    params.set('year', year);
+    params.set('week', week);
     router.push(`${pathname}?${params.toString()}`);
   };
 


### PR DESCRIPTION
## Summary by Sourcery

Enable filtering of admin submissions by week and year with sensible defaults, update the API to enforce week-based queries, and enhance the page with debounced fetches and improved loading/empty UIs

New Features:
- Add a WeekFilter component on the admin submissions page to filter submissions by week and year
- Default the week filter to the most recent Thursday week when no query parameters are provided

Bug Fixes:
- Ensure the submissions API always filters by week and year, defaulting to the current week when none is specified

Enhancements:
- Debounce fetching submissions when search or week selection changes
- Improve loading and empty states with a spinner and styled placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added filtering of submissions by both week and year on the admin submissions page.
  - Week and year filters now synchronize with URL parameters for easier sharing and persistence.

- **Improvements**
  - Enhanced loading and empty states with improved visuals and animations.
  - Updated filter and search input layout for a more organized appearance.
  - Improved handling of week and year selection throughout history and filter components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->