### PR TITLE
fix: fix update state from before call on Next

### DIFF
--- a/src/components/screens/ProjectSelectionScreen.tsx
+++ b/src/components/screens/ProjectSelectionScreen.tsx
@@ -16,6 +16,7 @@ export default function ProjectSelectionScreen({ onNext, formData, setFormData, 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const selectedProjectRef = useRef<HTMLButtonElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const pendingOtherProjectRef = useRef<string | null>(null);
 
   const filteredProjects = useMemo(() => {
     return projects.filter(project =>
@@ -100,10 +101,20 @@ export default function ProjectSelectionScreen({ onNext, formData, setFormData, 
 
   const handleOtherProjectSubmit = () => {
     if (otherProject.trim()) {
+      pendingOtherProjectRef.current = otherProject.trim();
       selectProject(otherProject.trim());
-      onNext();
     }
   };
+
+  useEffect(() => {
+    if (
+      pendingOtherProjectRef.current &&
+      formData.primaryProject.name === pendingOtherProjectRef.current
+    ) {
+      onNext();
+      pendingOtherProjectRef.current = null;
+    }
+  }, [formData.primaryProject.name, onNext]);
 
   const handleOtherClick = () => {
     setShowOtherInput(true);


### PR DESCRIPTION
## Summary by Sourcery

Wait for the project selection to propagate to state before calling onNext when submitting a custom “other” project

Bug Fixes:
- Delay invoking onNext until formData.primaryProject.name updates for custom projects

Enhancements:
- Introduce a ref to track pending custom project submissions and trigger navigation in a useEffect once state syncs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization when selecting and confirming a manually entered "other" project, ensuring smoother navigation and more reliable project selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->