### PR TITLE
fix: not mask email leader board anymore

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -34,16 +34,16 @@ interface FastestLeaderboardEntry {
   isCurrentUser?: boolean;
 }
 
-function maskEmail(email: string): string {
-  // Mask email for privacy (e.g., j***@gmail.com)
-  const [name, domain] = email.split('@');
-  if (!name || !domain) return email;
-  return name[0] + '***@' + domain;
+// Helper to capitalize every word
+function toTitleCase(str: string): string {
+  return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
 }
 
 function getDisplayName(user: User): string {
-  // if (user.name && user.name.trim() !== '') return user.name;
-  return maskEmail(user.email);
+  if (user.name && user.name.trim() !== '') return toTitleCase(user.name);
+  // If no name, use the part before @ in email
+  const [beforeAt] = user.email.split('@');
+  return toTitleCase(beforeAt);
 }
 
 function calculateMaxStreak(submissions: Submission[], allWeeks: Week[], currentWeek: number): number {


### PR DESCRIPTION
## Summary by Sourcery

Stop masking emails on the leaderboard and normalize display names by capitalizing each word from the user name or email prefix.

Bug Fixes:
- Remove email masking so full names or email prefixes are displayed on the leaderboard

Enhancements:
- Add a toTitleCase helper to capitalize each word in display names
- Update getDisplayName to use title-cased user names or fall back to the email local part

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User display names on the leaderboard now appear in title case for improved readability. If a name is unavailable, the prefix of the email address is shown in title case instead of a masked email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->