### PR TITLE
fix: update calculate streak when adding old data

### DIFF
--- a/src/app/(authenticated)/history/StreakCard.tsx
+++ b/src/app/(authenticated)/history/StreakCard.tsx
@@ -6,11 +6,13 @@ export default function StreakCard({
   allWeeks,
   submissions,
   currentWeek,
+  currentYear,
 }: {
   streak: number;
   allWeeks: { week_number: number; year: number }[];
   submissions: { week_number: number; year: number; submitted_at: string }[];
   currentWeek: number;
+  currentYear: number;
 }) {
   const key = (y: number, w: number) => `${y}-${w}`;
   const submittedWeeks = new Set(submissions.map(s => key(s.year, s.week_number)));
@@ -20,6 +22,48 @@ export default function StreakCard({
   const mid = Math.ceil(allWeeks.length / 2);
   const firstRow = allWeeks.slice(0, mid);
   const secondRow = allWeeks.slice(mid);
+
+  // Helper to render a week dot
+  function renderWeekDot(w: { year: number; week_number: number }) {
+    const isSubmitted = submittedWeeks.has(key(w.year, w.week_number));
+    const isCurrent = w.year === currentYear && w.week_number === currentWeek;
+    const isFuture = w.year > currentYear || (w.year === currentYear && w.week_number > currentWeek);
+
+    let dotClass = '';
+    let tooltip = '';
+    if (isFuture) {
+      dotClass = 'bg-white border-blue-300 border-2 dark:bg-transparent dark:border-blue-700';
+      tooltip = 'Upcoming';
+    } else if (isCurrent) {
+      dotClass = isSubmitted
+        ? 'bg-yellow-400 border-yellow-500'
+        : 'bg-white border-blue-500 animate-pulse ring-2 ring-blue-300 dark:bg-transparent dark:border-blue-400';
+      tooltip = isSubmitted ? 'This week: Submitted' : 'This week: Not submitted yet';
+    } else {
+      dotClass = isSubmitted
+        ? 'bg-yellow-400 border-yellow-500'
+        : 'bg-gray-200 border-gray-300 dark:bg-gray-700 dark:border-gray-600';
+      tooltip = isSubmitted ? 'Submitted' : 'Missed';
+    }
+
+    return (
+      <Tooltip key={`${w.year}-${w.week_number}`}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={`w-5 h-5 rounded-full ${dotClass} transition-all`}
+            aria-label={`Week ${w.week_number}: ${tooltip}`}
+          />
+        </TooltipTrigger>
+        <TooltipContent>
+          <div>
+            <div className="font-semibold">Week {w.week_number}</div>
+            <div>{tooltip}</div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
     <div className="mb-6">
@@ -31,88 +75,10 @@ export default function StreakCard({
         <div className="text-yellow-700 dark:text-yellow-300 font-semibold mb-2">Week Streak</div>
         <div className="flex flex-col gap-y-2 mb-2 overflow-x-auto max-w-full items-center">
           <div className="flex gap-1 justify-center">
-            {firstRow.map((w) => {
-              const isSubmitted = submittedWeeks.has(key(w.year, w.week_number));
-              const isCurrent = w.week_number === currentWeek;
-              const isFuture = w.week_number > currentWeek;
-
-              let dotClass = '';
-              let tooltip = '';
-              if (isFuture) {
-                dotClass = 'bg-white border-blue-300 border-2 dark:bg-transparent dark:border-blue-700';
-                tooltip = 'Upcoming';
-              } else if (isCurrent) {
-                dotClass = isSubmitted
-                  ? 'bg-yellow-400 border-yellow-500'
-                  : 'bg-white border-blue-500 animate-pulse ring-2 ring-blue-300 dark:bg-transparent dark:border-blue-400';
-                tooltip = isSubmitted ? 'This week: Submitted' : 'This week: Not submitted yet';
-              } else {
-                dotClass = isSubmitted
-                  ? 'bg-yellow-400 border-yellow-500'
-                  : 'bg-gray-200 border-gray-300 dark:bg-gray-700 dark:border-gray-600';
-                tooltip = isSubmitted ? 'Submitted' : 'Missed';
-              }
-
-              return (
-                <Tooltip key={`${w.year}-${w.week_number}`}>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className={`w-5 h-5 rounded-full ${dotClass} transition-all`}
-                      aria-label={`Week ${w.week_number}: ${tooltip}`}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div>
-                      <div className="font-semibold">Week {w.week_number}</div>
-                      <div>{tooltip}</div>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
+            {firstRow.map(renderWeekDot)}
           </div>
           <div className="flex gap-1 justify-center">
-            {secondRow.map((w) => {
-              const isSubmitted = submittedWeeks.has(key(w.year, w.week_number));
-              const isCurrent = w.week_number === currentWeek;
-              const isFuture = w.week_number > currentWeek;
-
-              let dotClass = '';
-              let tooltip = '';
-              if (isFuture) {
-                dotClass = 'bg-white border-blue-300 border-2 dark:bg-transparent dark:border-blue-700';
-                tooltip = 'Upcoming';
-              } else if (isCurrent) {
-                dotClass = isSubmitted
-                  ? 'bg-yellow-400 border-yellow-500'
-                  : 'bg-white border-blue-500 animate-pulse ring-2 ring-blue-300 dark:bg-transparent dark:border-blue-400';
-                tooltip = isSubmitted ? 'This week: Submitted' : 'This week: Not submitted yet';
-              } else {
-                dotClass = isSubmitted
-                  ? 'bg-yellow-400 border-yellow-500'
-                  : 'bg-gray-200 border-gray-300 dark:bg-gray-700 dark:border-gray-600';
-                tooltip = isSubmitted ? 'Submitted' : 'Missed';
-              }
-
-              return (
-                <Tooltip key={`${w.year}-${w.week_number}`}>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className={`w-5 h-5 rounded-full ${dotClass} transition-all`}
-                      aria-label={`Week ${w.week_number}: ${tooltip}`}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div>
-                      <div className="font-semibold">Week {w.week_number}</div>
-                      <div>{tooltip}</div>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
+            {secondRow.map(renderWeekDot)}
           </div>
         </div>
         <div className="text-sm text-yellow-800 dark:text-yellow-200">

--- a/src/app/(authenticated)/history/page.tsx
+++ b/src/app/(authenticated)/history/page.tsx
@@ -144,6 +144,7 @@ export default async function HistoryPage({
         allWeeks={filteredWeeks.filter(w => w.week_number >= 9)}
         submissions={submissions || []}
         currentWeek={currentWeek}
+        currentYear={currentYear}
       />
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>


### PR DESCRIPTION
## Summary by Sourcery

Exclude configured weeks from history data, refine streak calculation for old submissions, and enhance StreakCard with a two-row layout and informative tooltips

New Features:
- Add EXCLUDED_WEEKS configuration and isWeekExcluded helper to omit specified weeks from streak and filter calculations
- Split the streak calendar into two rows in StreakCard and incorporate tooltips on each week dot to indicate status

Bug Fixes:
- Use the provided year value in submissions instead of parsing dates to correctly mark historical weeks
- Update calculateStreak to operate on filtered weeks when incorporating old data

Enhancements:
- Adjust the starting week filter for the streak display from week 17 to week 9
- Refactor StreakCard to accept year in submissions and streamline dot rendering logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streak indicators now display in a two-row layout for improved clarity and accessibility.
  - Week dots include accessible labels and consistent tooltip content.
  - Weeks excluded by configuration are filtered out from history and streak calculations, ensuring accurate streak displays and week selection options.

- **Style**
  - Enhanced visual structure of the streak indicator for a clearer overview of weekly progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->