### PR TITLE
Fix pointer on profile button

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -65,9 +65,9 @@ export default function NavBar({ user }: NavBarProps) {
             </Link>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button 
-                  variant="ghost" 
-                  className="relative h-11 w-11 rounded-full bg-white/70 hover:bg-white/90 dark:bg-gray-900/80 dark:hover:bg-gray-800 transition-colors shadow-lg border border-white/30"
+                <Button
+                  variant="ghost"
+                  className="relative h-11 w-11 rounded-full bg-white/70 hover:bg-white/90 dark:bg-gray-900/80 dark:hover:bg-gray-800 transition-colors shadow-lg border border-white/30 cursor-pointer"
                 >
                   <span className="absolute bottom-1 right-1 block h-2.5 w-2.5 rounded-full bg-green-400 ring-2 ring-white dark:ring-gray-950 animate-pulse" />
                   <Avatar className="h-9 w-9">


### PR DESCRIPTION
## Summary
- fix cursor on profile button

## Testing
- `npx -y vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_b_684148c5eebc832b8922597290624b44

## Summary by Sourcery

Bug Fixes:
- Add cursor-pointer CSS class to the profile button to ensure the pointer cursor is shown on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the user dropdown trigger in the navigation bar to display a pointer cursor on hover, improving visual feedback for interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->