### PR TITLE
fix: fix test e2e

### DIFF
--- a/e2e/specs/weekly-pulse-e2e.spec.ts
+++ b/e2e/specs/weekly-pulse-e2e.spec.ts
@@ -65,7 +65,7 @@ test('Weekly Pulse E2E: submit form and verify post-submission state', async ({ 
     const token2 = await getAutoLoginToken(page, TEST_EMAIL);
     await page.goto(`/api/auth/auto-login?token=${token2}`);
     await expect(page.getByRole('heading', { name: /You're on fire! 🔥/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /View My Submission History/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /View Your Pulses/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /Start Weekly Pulse/i })).toHaveCount(0);
     await expect(page.getByRole('heading', { name: /What project did you spend most of your time on/i })).toHaveCount(0);
   });


### PR DESCRIPTION
## Summary by Sourcery

Fix the weekly pulse end-to-end test by updating the expected button label to 'View Your Pulses'

Bug Fixes:
- Update weekly pulse e2e test to expect the new 'View Your Pulses' button label instead of 'View My Submission History'

Tests:
- Adjust end-to-end spec to match updated button text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test to check for the "View Your Pulses" button label after login and submission instead of "View My Submission History".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->