### PR TITLE
refactor: update environment variable for company email domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=get-from-google-oauth-client-id
 TEST_USER_PASSWORD=Test123!
 JWT_SECRET=your-secure-secret
-COMPANY_EMAIL_DOMAIN=@yourcompany.com
+NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN=yourcompany.com
 CRON_SECRET=your-secure-random-string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ pnpm test:e2e:debug        # Run E2E tests in debug mode
 
 ### Key Business Logic
 - **Week calculations**: ISO week numbers with `date-fns` for consistency
-- **Auto-sharing**: Submissions auto-shared with managers for `@coderpush.com` emails
+- **Auto-sharing**: Submissions auto-shared with managers for NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN emails
 - **Streak calculation**: Configurable start week with exclusions for holidays
 - **Late submission detection**: Based on submission window timing
 

--- a/e2e/specs/auth.spec.ts
+++ b/e2e/specs/auth.spec.ts
@@ -37,8 +37,9 @@ test.describe('Authentication', () => {
     const googleButton = page.getByRole('button', { name: /Sign in with Google/i });
     await expect(googleButton).toBeVisible();
 
-    // Check for the footer note about @coderpush.com email
-    await expect(page.getByText('Please login with your @coderpush.com email.', { exact: false })).toBeVisible();
+    // Check for the footer note matching company domain email
+    const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+    await expect(page.getByText(`Please login with your @${companyDomain} email.`, { exact: false })).toBeVisible();
   });
 });
 

--- a/e2e/specs/auth.spec.ts
+++ b/e2e/specs/auth.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { autoLogin, createTestUser } from '../fixtures/auth';
+import { getCompanyDomain } from '@/utils/companyDomain';
 
 test.describe('Authentication', () => {
   test.beforeEach(async ({ page }) => {
@@ -38,7 +39,7 @@ test.describe('Authentication', () => {
     await expect(googleButton).toBeVisible();
 
     // Check for the footer note matching company domain email
-    const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+    const companyDomain = getCompanyDomain();
     await expect(page.getByText(`Please login with your @${companyDomain} email.`, { exact: false })).toBeVisible();
   });
 });

--- a/src/app/api/admin/submissions/[id]/share/route.ts
+++ b/src/app/api/admin/submissions/[id]/share/route.ts
@@ -62,12 +62,13 @@ export async function POST(
   if (userLookupError || !targetUser) {
     return NextResponse.json({ error: 'User does not exist' }, { status: 404 });
   }
-  // In production, only allow sharing with @coderpush.com emails
+  // In production, only allow sharing with company domain emails
+  const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
   if (
     process.env.NODE_ENV === 'production' &&
-    (!targetUser.email || !targetUser.email.endsWith('@coderpush.com'))
+    (!targetUser.email || !targetUser.email.endsWith(`@${companyDomain}`))
   ) {
-    return NextResponse.json({ error: 'Can only share with @coderpush.com emails in production' }, { status: 403 });
+    return NextResponse.json({ error: `Can only share with @${companyDomain} emails in production` }, { status: 403 });
   }
 
   const { error } = await supabase

--- a/src/app/api/admin/submissions/[id]/share/route.ts
+++ b/src/app/api/admin/submissions/[id]/share/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { sendEmail } from '@/lib/email';
 import { escapeHTML } from '@/lib/utils';
+import { getCompanyDomain } from '@/utils/companyDomain';
 
 export async function POST(
   req: NextRequest,
@@ -63,7 +64,7 @@ export async function POST(
     return NextResponse.json({ error: 'User does not exist' }, { status: 404 });
   }
   // In production, only allow sharing with company domain emails
-  const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+  const companyDomain = getCompanyDomain();
   if (
     process.env.NODE_ENV === 'production' &&
     (!targetUser.email || !targetUser.email.endsWith(`@${companyDomain}`))

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -1,6 +1,7 @@
 import createClient from '@/utils/supabase/api';
 import { NextResponse, NextRequest } from 'next/server';
 import { WeeklyPulseFormData } from '@/types/weekly-pulse';
+import { getCompanyDomain } from '@/utils/companyDomain';
 
 export async function POST(request: Request) {
   try {
@@ -121,7 +122,7 @@ export async function POST(request: Request) {
     // Auto-share with manager if manager is a coderpush.com email
     try {
       const managerEmail = submission.manager?.trim().toLowerCase();
-      const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+      const companyDomain = getCompanyDomain();
       if (managerEmail && managerEmail.endsWith(`@${companyDomain}`)) {
         const { data: managerUser } = await supabase
           .from('users')

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -121,7 +121,8 @@ export async function POST(request: Request) {
     // Auto-share with manager if manager is a coderpush.com email
     try {
       const managerEmail = submission.manager?.trim().toLowerCase();
-      if (managerEmail && managerEmail.endsWith('@coderpush.com')) {
+      const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+      if (managerEmail && managerEmail.endsWith(`@${companyDomain}`)) {
         const { data: managerUser } = await supabase
           .from('users')
           .select('id')

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 // The client you created from the Server-Side Auth instructions
 import { createClient} from '@/utils/supabase/server'
+import { getCompanyDomain } from '@/utils/companyDomain'
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
       const email = user?.email
 
       // Check if the email is from your company domain
-      const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+      const companyDomain = getCompanyDomain()
       if (!email || !email.endsWith(companyDomain)) {
         // Sign out the user
         await supabase.auth.signOut()

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
       const email = user?.email
 
       // Check if the email is from your company domain
-      const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+      const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
       if (!email || !email.endsWith(companyDomain)) {
         // Sign out the user
         await supabase.auth.signOut()

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
       const email = user?.email
 
       // Check if the email is from your company domain
-      const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+      const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || '@coderpush.com';
       if (!email || !email.endsWith(companyDomain)) {
         // Sign out the user
         await supabase.auth.signOut()

--- a/src/app/auth/invalid-domain/page.tsx
+++ b/src/app/auth/invalid-domain/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ShieldAlert } from "lucide-react";
 
-const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
 
 export default function InvalidDomainPage() {
   return (

--- a/src/app/auth/invalid-domain/page.tsx
+++ b/src/app/auth/invalid-domain/page.tsx
@@ -3,8 +3,9 @@ import { Alert, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ShieldAlert } from "lucide-react";
+import { getCompanyDomain } from '@/utils/companyDomain';
 
-const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+const companyDomain = getCompanyDomain();
 
 export default function InvalidDomainPage() {
   return (

--- a/src/app/auth/invalid-domain/page.tsx
+++ b/src/app/auth/invalid-domain/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ShieldAlert } from "lucide-react";
 
-const companyDomain = process.env.COMPANY_EMAIL_DOMAIN || '@coderpush.com';
+const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || '@coderpush.com';
 
 export default function InvalidDomainPage() {
   return (

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -19,6 +19,7 @@ function Mascot() {
 }
 
 export default function LoginPage() {
+  const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN;
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-100 via-indigo-100 to-purple-100">
       <Card className="w-full max-w-md mx-4 bg-white/70 backdrop-blur-md border border-white/30 shadow-2xl rounded-2xl animate-fade-in">
@@ -40,7 +41,7 @@ export default function LoginPage() {
           </div>
         </CardContent>
         <CardFooter className="flex flex-col items-center gap-2 pt-4">
-          <span className="text-sm text-muted-foreground">Please login with your @coderpush.com email.</span>
+          <span className="text-sm text-muted-foreground">Please login with your @{companyDomain} email.</span>
         </CardFooter>
       </Card>
     </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -2,6 +2,7 @@
 
 import GoogleSignInButton from '@/components/GoogleSignInButton';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { getCompanyDomain } from '@/utils/companyDomain';
 
 // Playful mascot SVG (calendar with a smile)
 function Mascot() {
@@ -19,7 +20,7 @@ function Mascot() {
 }
 
 export default function LoginPage() {
-  const companyDomain = process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN;
+  const companyDomain = getCompanyDomain();
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-100 via-indigo-100 to-purple-100">
       <Card className="w-full max-w-md mx-4 bg-white/70 backdrop-blur-md border border-white/30 shadow-2xl rounded-2xl animate-fade-in">

--- a/src/utils/companyDomain.ts
+++ b/src/utils/companyDomain.ts
@@ -1,0 +1,3 @@
+export function getCompanyDomain() {
+  return process.env.NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN || 'coderpush.com';
+} 


### PR DESCRIPTION
Use NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN instead of COMPANY_EMAIL_DOMAIN for email domain validation in login, callback, and invalid-domain pages

Enhancements:
- Rename environment variable from COMPANY_EMAIL_DOMAIN to NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN in authentication code

Documentation:
- Update .env.example to use NEXT_PUBLIC_COMPANY_EMAIL_DOMAIN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The company email domain is now dynamically retrieved and displayed throughout the application, including login prompts and error messages.
- **Bug Fixes**
  - Updated tests and logic to use the current company domain instead of a hardcoded value.
- **Chores**
  - Environment variable for the company email domain has been renamed and reformatted for consistency.
- **Documentation**
  - Updated documentation to reflect the generalized auto-sharing feature based on the dynamic company domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->