### PR TITLE
Fix: chart now shows most recent weeks first

### DIFF
--- a/src/components/ProjectLineChart.tsx
+++ b/src/components/ProjectLineChart.tsx
@@ -44,9 +44,16 @@ export default function ProjectLineChart({ data, weekMeta }: Props) {
 
   // Pagination state for weeks
   const WINDOW_SIZE = 3;
-  const [windowStart, setWindowStart] = useState(0);
+  const [windowStart, setWindowStart] = useState(() =>
+    Math.max(0, data.length - WINDOW_SIZE)
+  );
   const maxWindowStart = Math.max(0, data.length - WINDOW_SIZE);
   const visibleData = data.slice(windowStart, windowStart + WINDOW_SIZE);
+
+  // Update windowStart if data length changes (e.g., new data loaded)
+  useEffect(() => {
+    setWindowStart(Math.max(0, data.length - WINDOW_SIZE));
+  }, [data.length, WINDOW_SIZE]);
 
   // Project visibility state
   const [visibleProjects, setVisibleProjects] = useState<


### PR DESCRIPTION
Updated so that chart now shows most recent weeks first.

## Summary by Sourcery

Show the most recent weeks first in the project line chart and update the visible window when new data arrives.

Bug Fixes:
- Show most recent weeks in the chart by default instead of the oldest

Enhancements:
- Reinitialize the chart window start when data length changes to keep the view on the latest weeks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The chart now automatically displays the most recent data when loaded or when new data is added, ensuring users always see the latest information first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->