### PR TITLE
fix: route admin dailytask by user id

### DIFF
--- a/src/app/api/admin/daily-tasks/route.ts
+++ b/src/app/api/admin/daily-tasks/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
     .range(offset, offset + pageSize - 1);
 
   if (user) {
-    query = query.ilike('user.email', `%${user}%`);
+    query = query.eq('user_id', user);
   }
   if (month) {
     query = query.gte('task_date', `${month}-01`).lte('task_date', `${month}-31`);

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const search = searchParams.get('search');
     const wantsDailyReminders = searchParams.get('wants_daily_reminders');
+    const userId = searchParams.get('userId');
 
     // Build the query
     let query = supabase
@@ -37,13 +38,18 @@ export async function GET(request: Request) {
       .select('*')
       .order('created_at', { ascending: false });
 
-    // Apply search filter if provided
-    if (search) {
-      query = query.or(`email.ilike.%${search}%,name.ilike.%${search}%`);
-    }
+    // If userId is provided, get specific user
+    if (userId) {
+      query = query.eq('id', userId);
+    } else {
+      // Apply search filter if provided
+      if (search) {
+        query = query.or(`email.ilike.%${search}%,name.ilike.%${search}%`);
+      }
 
-    if (wantsDailyReminders === 'true') {
-      query = query.eq('wants_daily_reminders', true);
+      if (wantsDailyReminders === 'true') {
+        query = query.eq('wants_daily_reminders', true);
+      }
     }
 
     const { data: users, error } = await query;


### PR DESCRIPTION
## Summary by Sourcery

Add filtering by userId to the admin users endpoint and switch daily-tasks filtering from user email to user_id

Enhancements:
- Support fetching a specific user in the admin/users route when a userId query parameter is provided
- Apply exact user_id matching for filtering in the admin/daily-tasks route instead of using email substring search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to filter users by a specific user ID in the user management interface.

* **Bug Fixes**
  * Improved accuracy of daily task filtering by matching tasks to users strictly by user ID instead of partial email matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->