### PR TITLE
feat: add button copy daily report

### DIFF
--- a/src/app/(authenticated)/ai-demo-page/parse/TaskSummaryList.tsx
+++ b/src/app/(authenticated)/ai-demo-page/parse/TaskSummaryList.tsx
@@ -1,6 +1,7 @@
-import { CalendarDays, ChevronDown, ChevronRight, Link as LinkIcon } from "lucide-react";
+import { CalendarDays, ChevronDown, ChevronRight, Link as LinkIcon, Copy } from "lucide-react";
 import React from "react";
 import { Task } from "../page";
+import { useToast } from "@/components/ui/use-toast";
 
 interface TaskSummaryListProps {
   tasks: Task[];
@@ -21,6 +22,8 @@ const TaskSummaryList: React.FC<TaskSummaryListProps> = ({
   setExpandedDates,
   isGroupEmpty,
 }) => {
+  const { toast } = useToast();
+
   const handleDelete = async (taskId: string) => {
     const originalTasks = tasks;
     setTasks(prevTasks => prevTasks.filter(task => task.id !== taskId));
@@ -34,6 +37,68 @@ const TaskSummaryList: React.FC<TaskSummaryListProps> = ({
     } catch (error) {
       setTasks(originalTasks);
       console.error("Error deleting task:", error);
+    }
+  };
+
+  const handleCopyDayTasks = async (date: string, taskItems: Array<Task & { _idx: number }>) => {
+    if (taskItems.length === 0) {
+      toast({
+        title: "No tasks to copy",
+        description: "There are no tasks available for this day to copy.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const totalHours = taskItems.reduce((sum, task) => {
+      const h = Number(task.hours || "0");
+      return sum + (isNaN(h) ? 0 : h);
+    }, 0);
+
+    let displayDate = date;
+    if (date !== "Unknown" && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      const d = new Date(date);
+      if (!isNaN(d.getTime())) {
+        displayDate = d.toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'short', day: 'numeric' });
+      }
+    }
+
+    let formattedText = `${displayDate} - Daily Tasks (${totalHours}h total)\n`;
+    formattedText += "=".repeat(displayDate.length + 25) + "\n\n";
+
+    taskItems.forEach((task) => {
+      formattedText += `• ${task.hours || "0"}h - ${task.description || "No description"}`;
+      if (task.project) {
+        formattedText += ` (${task.project})`;
+      }
+      if (task.bucket) {
+        formattedText += ` [${task.bucket}]`;
+      }
+      if (task.link) {
+        formattedText += ` - ${task.link}`;
+      }
+      formattedText += "\n";
+    });
+
+    try {
+      await navigator.clipboard.writeText(formattedText);
+      toast({
+        title: "Tasks copied!",
+        description: `Tasks for ${displayDate} have been copied to your clipboard.`,
+      });
+    } catch (error) {
+      console.error("Failed to copy to clipboard:", error);
+      // Fallback: create a temporary textarea
+      const textarea = document.createElement("textarea");
+      textarea.value = formattedText;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      toast({
+        title: "Tasks copied!",
+        description: `Tasks for ${displayDate} have been copied to your clipboard.`,
+      });
     }
   };
 
@@ -77,6 +142,18 @@ const TaskSummaryList: React.FC<TaskSummaryListProps> = ({
                     {totalHours} <span className="ml-1">hours</span>
                   </span>
                 </div>
+                {/* Copy button for this day */}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCopyDayTasks(date, taskItems);
+                  }}
+                  className="flex items-center gap-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded-lg text-sm font-medium transition-colors"
+                  title={`Copy tasks for ${displayDate}`}
+                >
+                  <Copy className="w-3 h-3" />
+                  Copy
+                </button>
               </div>
               {expanded && (
                 <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Summary by Sourcery

Add a copy button to the daily task summary list to allow users to quickly copy a formatted daily report (including total hours and task details) to the clipboard with toast notifications and a fallback mechanism.

New Features:
- Implement handleCopyDayTasks to aggregate total hours, format task details as plaintext, and copy the report to the clipboard with a navigator.clipboard and fallback approach
- Add a 'Copy' button with an icon next to each date header in TaskSummaryList that invokes the copy functionality and displays success or error toasts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy" button next to each day's task summary, allowing users to copy all tasks for that day to the clipboard in a formatted text block.
  * Users receive instant feedback via notifications indicating the success or failure of the copy action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->