### PR TITLE
feat: update user lists only reminder people

### DIFF
--- a/src/app/admin/daily-tasks/page.tsx
+++ b/src/app/admin/daily-tasks/page.tsx
@@ -11,6 +11,7 @@ interface User {
   id: string;
   email: string;
   name?: string | null;
+  wants_daily_reminders?: boolean;
 }
 
 type AdminDailyTask = {
@@ -44,6 +45,9 @@ export default function AdminDailyTasksPage() {
       .then(res => res.json())
       .then(data => setUserList(data.data || []));
   }, []);
+
+  // Only show users who want daily reminders
+  const filteredUserList = userList.filter(user => user.wants_daily_reminders);
 
   // Fetch tasks from backend
   useEffect(() => {
@@ -94,7 +98,7 @@ export default function AdminDailyTasksPage() {
               <Command>
                 <CommandInput placeholder="Search user..." />
                 <CommandList>
-                  {userList.map(user => (
+                  {filteredUserList.map(user => (
                     <CommandItem
                       key={user.id}
                       onSelect={() => {
@@ -106,7 +110,7 @@ export default function AdminDailyTasksPage() {
                       {user.email} {user.name && `(${user.name})`}
                     </CommandItem>
                   ))}
-                  {userList.length === 0 && (
+                  {filteredUserList.length === 0 && (
                     <CommandItem disabled>No users found</CommandItem>
                   )}
                 </CommandList>


### PR DESCRIPTION
## Summary by Sourcery

Filter the admin daily tasks user picker to only show users who have opted in for daily reminders by introducing and utilizing a new ‘wants_daily_reminders’ field on the User interface.

New Features:
- Add optional ‘wants_daily_reminders’ boolean to User interface
- Apply a filter to display only users with daily reminders enabled in the user selection command list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User selection now only displays users who have opted in for daily reminders.
  * Improved empty state messaging when no eligible users are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->